### PR TITLE
Keep relative humidity, rework null/missing values

### DIFF
--- a/src/met-office/odbapi2nc.py
+++ b/src/met-office/odbapi2nc.py
@@ -155,8 +155,6 @@ while row is not None:
     profileKey = row.statid.rstrip(), anDateTimeString
     #TODO: For now we convert pressure (vertco_reference_1) to hPa here. No units stored yet.
     pressure = row.vertco_reference_1 / 100.0 if row.vertco_reference_1 is not None else IODA_MISSING_VAL
-    if pressure == IODA_MISSING_VAL:
-        print row.lat, row.lon, pressure, obsDateTimeString
     locationKey = row.lat, row.lon, pressure, obsDateTimeString
     ovalKey = varName, iconv.OVAL_NAME
     oerrKey = varName, iconv.OERR_NAME


### PR DESCRIPTION
Do not delete relative humidity after converting it to specific humidity, so that both values get into IODA. Also changed select statement so that we are not "pruning" the data in the file so much. Instead, more missing values get converted.