### PR TITLE
Feature/bufr ships 001001 sf

### DIFF
--- a/src/ncep/bufr2nc.py
+++ b/src/ncep/bufr2nc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+###!/usr/bin/env python
 
 from __future__ import print_function
 import ncepbufr
@@ -12,6 +12,7 @@ from netCDF4 import Dataset
 
 import bufr2ncCommon as cm
 import bufr2ncObsTypes as ot
+
 
 ###################################################################################
 # SUBROUTINES
@@ -37,6 +38,9 @@ def BfilePreprocess(BufrFname, Obs):
 ###################################################################################
 # MAIN
 ###################################################################################
+
+print(set(sys.modules) & set(globals()))
+
 ScriptName = os.path.basename(sys.argv[0])
 
 # Parse command line
@@ -66,6 +70,7 @@ if (MyArgs.prepbufr):
 else:
     BfileType = cm.BFILE_BUFR
 
+print('BfileType = ',BfileType)
 # Check files
 BadArgs = False
 if (not os.path.isfile(BufrFname)): 
@@ -92,6 +97,11 @@ elif (ObsType == 'Amsua'):
     Obs = ot.AmsuaObsType(BfileType)
 elif (ObsType == 'Gpsro'):
     Obs = ot.GpsroObsType(BfileType)
+elif (ObsType == 'NC001001'):
+    print('ShipsObsType:', ObsType)
+    Obs = ot.ShipsObsType(BfileType)
+#    sys.exit (0)
+      
 else:
     print("ERROR: {0:s}: Unknown observation type: {1:s}".format(ScriptName, ObsType))
     print("")

--- a/src/ncep/bufr2ncObsTypes.py
+++ b/src/ncep/bufr2ncObsTypes.py
@@ -678,6 +678,150 @@ class ObsType(object):
         print("  Total converted observations: ", ObsNum)
         print("")
 
+
+
+################################# Ships Observations ############################
+
+
+class ShipsObsType(ObsType):
+    ### initialize data elements ###
+    def __init__(self, bf_type):
+        super(ShipsObsType, self).__init__()
+
+        self.bufr_ftype = bf_type
+        self.multi_level = False
+
+        # Put the time and date vars in the subclasses so that their dimensions can
+        # vary ( [nobs], [nobs,nlevs] ).
+        self.misc_spec[0].append([ 'ObsTime',   '', cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ])
+        self.misc_spec[0].append([ 'ObsDate',   '', cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ])
+        self.misc_spec[0].append([ 'time',      '', cm.DTYPE_DOUBLE,  ['nobs'], [self.nobs] ])
+        self.misc_spec[0].append([ 'latitude',  '', cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ])
+        self.misc_spec[0].append([ 'longitude', '', cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ])
+
+        if (bf_type == cm.BFILE_BUFR):
+            self.mtype_re = '^NC001001'
+            self.int_spec = [
+                [ [ 'YEAR',   'YEAR',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'MNTH',   'MNTH',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'DAYS',   'DAYS',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'HOUR',   'HOUR',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'MINU',   'MINU',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'ACID',   'ACID',   cm.DTYPE_DOUBLE,  ['nobs'], [self.nobs] ],
+                  [ 'CORN',   'CORN',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'CLAT',   'CLAT',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'CLON',   'CLON',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ], 
+                  [ 'SELV',   'SELV',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+
+                [ [ 'SEQNUM', 'SEQNUM', cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'BUHD',   'BUHD',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'BORG',   'BORG',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'BULTIM', 'BULTIM', cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'BBB',    'BBB',    cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ]],
+
+                [  [ 'RPID',   'RPID',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ] ],
+
+                [ [ 'ITSO',   'ITSO',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'TOST',   'TOST',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'INPC',   'INPC',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ] ],
+
+                [ [ 'HOVI',   'HOVI',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TIWM',   'TIWM',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'QMWN',   'QMWN',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'WDIR',   'WDIR',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'WSPD',   'WSPD',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+
+                [ [ 'QMAT',   'QMAT',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'TMDE',   'TMDE',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'QMDD',   'QMDD',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'TMDP',   'TMDP',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'MSST',   'MSST',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'QMST',   'QMST',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'SST1',   'SST1',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'MWBT',   'MWBT',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TMWB',   'TMWB',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'REHU',   'REHU',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'MXTM',   'MXTM',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'MITM',   'MITM',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+                  
+                            
+                [ [ 'QMPR',   'QMPR',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'PRES',   'PRES',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'PMSL',   'PMSL',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'CHPT',   'CHPT',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ '3HPC',   '3HPC',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ '24PC',   '24PC',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+
+                [ [ 'TP01',   'TP01',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TP03',   'TP03',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TP06',   'TP06',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TP12',   'TP12',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'TP24',   'TP24',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+                  
+               [  [ 'TOCC',   'TOCC',   cm.DTYPE_FLOAT,    ['nobs'], [self.nobs] ],
+                  [ 'HBLCS',  'HBLCS',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ] ], 
+
+#               [   [ 'VSSO',   'VSSO',   cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ], 
+#                   [ 'CLAM',   'CLAM',   cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+#                   [ 'CLTP',   'CLTP',   cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ] ], 
+              
+               [  [ 'PRWE',   'PRWE',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+                  [ 'PSW1',   'PSW1',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+                  [ 'PSW2',   'PSW2',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ] ], 
+              
+               [  [ 'HOWV',   'HOWV',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ], 
+                  [ 'POWV',   'POWV',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'QMWH',   'QMWH',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],  
+                  [ 'HOWW',   'HOWW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+                  [ 'POWW',   'POWW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+                  
+#               [  [ 'POSW',   'POSW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+#                  [ 'DOSW',   'DOSW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
+#                  [ 'HOSW',   'HOSW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+
+               [  [ 'TDMP',   'TDMP',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+                  [ 'ASMP',   'ASMP',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ] ], 
+
+               [  [ 'COIA',   'COIA',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+                  [ 'ROIA',   'ROIA',  cm.DTYPE_INTEGER,  ['nobs'], [self.nobs] ],
+                  [ 'IDTH',   'IDTH',  cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+
+               [  [ 'VTVI',   'VTVI',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
+                
+               ]
+            self.evn_spec = []
+            self.rep_spec = []
+            self.seq_spec = []
+        # Set the dimension specs.
+        super(ShipsObsType, self).init_dim_spec()
+
+    ### methods ###
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ################################# Aircraft Observation Type ############################
 class AircraftObsType(ObsType):
     ### initialize data elements ###

--- a/src/ncep/bufr2ncObsTypes.py
+++ b/src/ncep/bufr2ncObsTypes.py
@@ -726,17 +726,17 @@ class ShipsObsType(ObsType):
                   [ 'INPC',   'INPC',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ] ],
 
                 [ [ 'HOVI',   'HOVI',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
-                  [ 'TIWM',   'TIWM',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
-                  [ 'QMWN',   'QMWN',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'TIWM',   'TIWM',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'QMWN',   'QMWN',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ 'WDIR',   'WDIR',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ 'WSPD',   'WSPD',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
 
-                [ [ 'QMAT',   'QMAT',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                [ [ 'QMAT',   'QMAT',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ 'TMDE',   'TMDE',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
-                  [ 'QMDD',   'QMDD',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'QMDD',   'QMDD',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ 'TMDP',   'TMDP',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
-                  [ 'MSST',   'MSST',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
-                  [ 'QMST',   'QMST',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'MSST',   'MSST',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
+                  [ 'QMST',   'QMST',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ 'SST1',   'SST1',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ 'MWBT',   'MWBT',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ 'TMWB',   'TMWB',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
@@ -745,10 +745,10 @@ class ShipsObsType(ObsType):
                   [ 'MITM',   'MITM',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
                   
                             
-                [ [ 'QMPR',   'QMPR',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                [ [ 'QMPR',   'QMPR',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ 'PRES',   'PRES',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ 'PMSL',   'PMSL',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
-                  [ 'CHPT',   'CHPT',   cm.DTYPE_STRING,  ['nobs', 'nstring'], [self.nobs, self.nstring] ],
+                  [ 'CHPT',   'CHPT',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],
                   [ '3HPC',   '3HPC',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ '24PC',   '24PC',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
 
@@ -771,7 +771,7 @@ class ShipsObsType(ObsType):
               
                [  [ 'HOWV',   'HOWV',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ], 
                   [ 'POWV',   'POWV',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
-                  [ 'QMWH',   'QMWH',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],  
+                  [ 'QMWH',   'QMWH',   cm.DTYPE_INTEGER, ['nobs'], [self.nobs] ],  
                   [ 'HOWW',   'HOWW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ],
                   [ 'POWW',   'POWW',   cm.DTYPE_FLOAT,   ['nobs'], [self.nobs] ] ],
                   


### PR DESCRIPTION
The bufr2nc.py and bufr2ncObsTypes.py were updated to convert **ship** sea surface observations from BUFR (**NCEP tank b001/xx001**) to NC4. 

The output includes all the data, metadata and attributes of the original file. 

@srherbener Could you check these two issues: 
1. Some sequence descriptors are handled as elements; therefore few datasets are not imported.  
2. Not optimized. 

@guillaumevernieres Let me know when you have time to try using the SST observations from NC4 file. 

