### PR TITLE
Feature/godae-nc-writer

### DIFF
--- a/src/marine/altimeter/altimeter2ioda.py
+++ b/src/marine/altimeter/altimeter2ioda.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
             dofy_file = int(filename[-6:-3])
             dofy_da = datetime.datetime.strptime(args.date[0:8],"%Y%m%d")
             dofy_da = dofy_da.timetuple().tm_yday
-            if (abs(1.0*(dofy_file-dofy_da))<=int(args.window)/24.0):
+            if (abs(1.0*(dofy_file-dofy_da))<=np.ceil(float(args.window)/24.0)):
                 print(filename)            
                 if (cnt==0):
                     adt = preobs(filename=filename, window_length=int(args.window), midwindow_date=midwindow_date)

--- a/src/marine/godae/profile2ioda.py
+++ b/src/marine/godae/profile2ioda.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import numpy as np
 from datetime import datetime
-from scipy.io import FortranFile, netcdf
+from scipy.io import FortranFile
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from collections import defaultdict
 import ioda_conv_ncio as iconv
@@ -135,9 +135,8 @@ class profile(object):
         return
 
     def to_ioda(self):
-
         '''
-        Selectively (e.g. salinity, temperature) convert odata into idata
+        Selectively convert odata into idata.
         idata is the IODA required data structure
         '''
 

--- a/src/marine/godae/profile2ioda.py
+++ b/src/marine/godae/profile2ioda.py
@@ -9,8 +9,6 @@ from collections import defaultdict
 import ioda_conv_ncio as iconv
 
 
-vName = "obs_absolute_dynamic_topography",
-
 class profile(object):
 
     def __init__(self, filename, date):
@@ -136,124 +134,30 @@ class profile(object):
 
         return
 
-    def _to_nlocs(self):
+    def to_ioda(self):
+
         '''
         Selectively (e.g. salinity, temperature) convert odata into idata
-        idata is the IODA required data structure, where profiles are stacked
-        on top of each other into a single vector.
+        idata is the IODA required data structure
         '''
-
-        # idata is the dictionary containing IODA friendly data structure
-        idata = {}
-
-        idata['ob_lat'] = []
-        idata['ob_lon'] = []
-        idata['ob_lvl'] = []
-        idata['ob_dtg'] = []
-        idata['ob_sal'] = []
-        idata['ob_sal_err'] = []
-        idata['ob_tmp'] = []
-        idata['ob_tmp_err'] = []
-
-        for n in range(self.odata['n_obs']):
-
-            lat = self.odata['ob_lat'][n]
-            lon = self.odata['ob_lon'][n]
-            dtg = datetime.strptime(self.odata['ob_dtg'][n], '%Y%m%d%H%M')
-
-            # Diff. between ob. time and time in the file (hrs)!
-            #ddtg = (dtg - self.date).total_seconds()/3600.
-
-            for l, lvl in enumerate(self.odata['ob_lvl'][n]):
-
-                idata['ob_lat'].append(lat)
-                idata['ob_lon'].append(lon)
-                #idata['ob_dtg'].append(ddtg)
-                idata['ob_dtg'].append(dtg)  # provide absolute time
-                idata['ob_lvl'].append(lvl)
-                idata['ob_sal'].append(self.odata['ob_sal'][n][l])
-                idata['ob_sal_err'].append(self.odata['ob_sal_err'][n][l])
-                idata['ob_tmp'].append(self.odata['ob_tmp'][n][l])
-                idata['ob_tmp_err'].append(self.odata['ob_tmp_err'][n][l])
-
-        idata['nlocs'] = len(idata['ob_dtg'])
-
-        self.idata = idata
-
-        return
-
-    def to_ioda(self):
 
         if self.odata['n_obs'] <= 0:
             print('No profile observations for IODA!')
             return
 
-        self._to_nlocs()
+        locationKeyList = [
+            ("latitude", "float"),
+            ("longitude", "float"),
+            ("level", "float"),
+            ("date_time", "string")
+        ]
 
-        ncid = netcdf.netcdf_file(self.filename + '.nc', mode='w')
+        AttrData = {
+            'odb_version': 1,
+            'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        }
 
-        ncid.createDimension('nlocs', self.idata['nlocs'])  # no. of obs per var type
-        ncid.createDimension('nrecs', 1)  # no. of profiles
-        ncid.createDimension('nvars', 1)  # no. of variables
-        ncid.createDimension('nobs', 1*self.idata['nlocs'])  # total no. of obs
-
-        longitudes = ncid.createVariable('longitude@MetaData', 'f4', ('nlocs',))
-        longitudes.units = 'degrees_east'
-
-        latitudes = ncid.createVariable('latitude@MetaData', 'f4', ('nlocs',))
-        latitudes.units = 'degrees_north'
-
-        times = ncid.createVariable('time@MetaData', 'f4', ('nlocs',))
-        times.long_name = 'observation time from date_time'
-        times.units = 'hours'
-        times.description = 'why does this have to be with a reference to, why not absolute?'
-
-        depths = ncid.createVariable('ocean_depth@MetaData', 'f4', ('nlocs',))
-        depths.units = 'meters'
-        depths.positive = 'down'
-
-        sals = ncid.createVariable('ocean_salinity@ObsValue', 'f4', ('nlocs',))
-        sals.units = 'g/kg'
-        sals.description = ''
-
-        sal_errs = ncid.createVariable(
-            'ocean_salinity@ObsError', 'f4', ('nlocs',))
-        sal_errs.units = '(g/kg)'
-        sal_errs.description = 'Standard deviation of observation error'
-
-        tmps = ncid.createVariable(
-            'insitu_temperature@ObsValue', 'f4', ('nlocs',))
-        tmps.units = 'degree_celcius'
-        tmps.description = ''
-
-        tmp_errs = ncid.createVariable(
-            'insitu_temperature@ObsError', 'f4', ('nlocs',))
-        tmp_errs.units = '(degree_celcius)'
-        tmp_errs.description = 'Standard deviation of observation error'
-
-        ncid.date_time = int(datetime.strftime(self.date, '%Y%m%d%H%M')[0:10])
-
-        longitudes[:] = np.asarray(self.idata['ob_lon'], dtype=np.float32)
-        latitudes[:] = np.asarray(self.idata['ob_lat'], dtype=np.float32)
-        depths[:] = np.asarray(self.idata['ob_lvl'], dtype=np.float32)
-        times[:] = np.asarray(self.idata['ob_dtg'], dtype=np.float32)
-
-        sals[:] = np.asarray(self.idata['ob_sal'], dtype=np.float32)
-        sal_errs[:] = np.asarray(self.idata['ob_sal_err'], dtype=np.float32)
-
-        tmps[:] = np.asarray(self.idata['ob_tmp'], dtype=np.float32)
-        tmp_errs[:] = 0.5 + np.asarray(self.idata['ob_tmp_err'], dtype=np.float32)
-
-        ncid.close()
-
-        return
-
-    def _to_NcWriter(self, writer):
-        '''
-        Selectively (e.g. salinity, temperature) convert odata into idata
-        idata is the IODA required data structure, where profiles are stacked
-        on top of each other into a single vector.
-        '''
+        writer = iconv.NcWriter(self.filename+'.nc', [], locationKeyList)
 
         # idata is the dictionary containing IODA friendly data structure
         idata = defaultdict(lambda: defaultdict(dict))
@@ -281,8 +185,6 @@ class profile(object):
 
                 locKey = lat, lon, lvl, dtg.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-                print("val = %f" % self.odata['ob_tmp'][n][l])
-
                 idata[n][locKey][tmp_valKey] = self.odata['ob_tmp'][n][l]
                 idata[n][locKey][tmp_errKey] = self.odata['ob_tmp_err'][n][l]
                 idata[n][locKey][tmp_qcKey] = tmp_qc
@@ -291,33 +193,7 @@ class profile(object):
                 idata[n][locKey][sal_errKey] = self.odata['ob_sal_err'][n][l]
                 idata[n][locKey][sal_qcKey] = sal_qc
 
-        self.idata = idata
-
-        return
-
-    def to_iodaNcWriter(self):
-
-        if self.odata['n_obs'] <= 0:
-            print('No profile observations for IODA!')
-            return
-
-        locationKeyList = [
-            ("latitude", "float"),
-            ("longitude", "float"),
-            ("level", "float"),
-            ("date_time", "string")
-            ]
-
-        AttrData = {
-          'odb_version': 1,
-          'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
-           }
-
-        writer = iconv.NcWriter(self.filename+'.nc', [], locationKeyList)
-
-        self._to_NcWriter(writer)
-
-        writer.BuildNetcdf(self.idata, AttrData)
+        writer.BuildNetcdf(idata, AttrData)
 
         return
 
@@ -340,5 +216,4 @@ if __name__ == '__main__':
     fdate = datetime.strptime(args.date, '%Y%m%d%H%M')
 
     prof = profile(fname, fdate)
-    #prof.to_ioda()
-    prof.to_iodaNcWriter()
+    prof.to_ioda()

--- a/src/marine/godae/ship2ioda.py
+++ b/src/marine/godae/ship2ioda.py
@@ -118,7 +118,7 @@ class ship(object):
 
             lat = self.odata['ob_lat'][n]
             lon = self.odata['ob_lon'][n]
-            dtg = datetime.strptime(self.odata['ob_dtg'][i], '%Y%m%d%H%M')
+            dtg = datetime.strptime(self.odata['ob_dtg'][n], '%Y%m%d%H%M')
 
             locKey = lat, lon, dtg.strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/src/marine/godae/ship2ioda.py
+++ b/src/marine/godae/ship2ioda.py
@@ -3,8 +3,10 @@
 from __future__ import print_function
 import numpy as np
 from datetime import datetime
-from scipy.io import FortranFile, netcdf
+from scipy.io import FortranFile
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from collections import defaultdict
+import ioda_conv_ncio as iconv
 
 
 class ship(object):
@@ -81,72 +83,50 @@ class ship(object):
 
         return
 
-    def _to_nlocs(self):
+    def to_ioda(self):
         '''
-        Selectively (e.g. salinity, temperature) convert odata into idata
+        Selectively convert odata into idata.
         idata is the IODA required data structure
         '''
-
-        # idata is the dictionary containing IODA friendly data structure
-        idata = self.odata
-
-        # Diff. between ob. time and time in the file (hrs)!
-        for i in range(self.odata['n_obs']):
-            dtg = datetime.strptime(self.odata['ob_dtg'][i], '%Y%m%d%H%M')
-            idata['ob_dtg'][i] = (dtg - self.date).total_seconds()/3600.
-
-        idata['nlocs'] = len(idata['ob_dtg'])
-
-        self.idata = idata
-
-        return
-
-    def to_ioda(self):
 
         if self.odata['n_obs'] <= 0:
             print('No ship observations for IODA!')
             return
 
-        self._to_nlocs()
+        locationKeyList = [
+            ("latitude", "float"),
+            ("longitude", "float"),
+            ("date_time", "string")
+        ]
 
-        ncid = netcdf.netcdf_file(self.filename + '.nc', mode='w')
+        AttrData = {
+            'odb_version': 1,
+            'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        }
 
-        ncid.createDimension('nlocs', self.idata['nlocs'])  # no. of obs per var type
-        ncid.createDimension('nrecs', 1)  # no. of obs.
-        ncid.createDimension('nvars', 1)  # no. of variables
-        ncid.createDimension('nobs', 1*self.idata['nlocs'])  # total no. of obs
+        writer = iconv.NcWriter(self.filename+'.nc', [], locationKeyList)
 
-        longitudes = ncid.createVariable('longitude@MetaData', 'f4', ('nlocs',))
-        longitudes.units = 'degrees_east'
+        # idata is the dictionary containing IODA friendly data structure
+        idata = defaultdict(lambda: defaultdict(dict))
 
-        latitudes = ncid.createVariable('latitude@MetaData', 'f4', ('nlocs',))
-        latitudes.units = 'degrees_north'
+        varName = 'sea_surface_temperature'
+        valKey = varName, writer.OvalName()
+        errKey = varName, writer.OerrName()
+        qcKey = varName, writer.OqcName()
 
-        times = ncid.createVariable('time@MetaData', 'f4', ('nlocs',))
-        times.long_name = 'observation time from date_time'
-        times.units = 'hours'
-        times.description = 'why does this have to be with a reference to, why not absolute?'
+        for n in range(self.odata['n_obs']):
 
-        tmps = ncid.createVariable(
-            'sea_surface_temperature@ObsValue', 'f4', ('nlocs',))
-        tmps.units = 'degree_celcius'
-        tmps.description = ''
+            lat = self.odata['ob_lat'][n]
+            lon = self.odata['ob_lon'][n]
+            dtg = datetime.strptime(self.odata['ob_dtg'][i], '%Y%m%d%H%M')
 
-        tmp_errs = ncid.createVariable(
-            'sea_surface_temperature@ObsError', 'f4', ('nlocs',))
-        tmp_errs.units = '(degree_celcius)'
-        tmp_errs.description = 'Standard deviation of observation error; Fixed at 0.5'
+            locKey = lat, lon, dtg.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        ncid.date_time = int(datetime.strftime(self.date, '%Y%m%d%H%M')[0:10])
+            idata[0][locKey][valKey] = self.odata['ob_sst'][n]
+            idata[0][locKey][errKey] = 0.5
+            idata[0][locKey][qcKey] = self.odata['ob_qc'][n]
 
-        longitudes[:] = np.asarray(self.idata['ob_lon'], dtype=np.float32)
-        latitudes[:] = np.asarray(self.idata['ob_lat'], dtype=np.float32)
-        times[:] = np.asarray(self.idata['ob_dtg'], dtype=np.float32)
-
-        tmps[:] = np.asarray(self.idata['ob_sst'], dtype=np.float32)
-        tmp_errs[:] = 0.5
-
-        ncid.close()
+        writer.BuildNetcdf(idata, AttrData)
 
         return
 
@@ -160,7 +140,7 @@ if __name__ == '__main__':
         '-n', '--name', help='name of the binary GODAE ship file (path)',
         type=str, required=True)
     parser.add_argument(
-        '-d', '--date', help='file date', type=str, required=True)
+        '-d', '--date', help='file date', type=str, metavar='YYYYMMDDHH', required=True)
 
     args = parser.parse_args()
 

--- a/src/marine/godae/trak2ioda.py
+++ b/src/marine/godae/trak2ioda.py
@@ -3,8 +3,10 @@
 from __future__ import print_function
 import numpy as np
 from datetime import datetime
-from scipy.io import FortranFile, netcdf
+from scipy.io import FortranFile
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from collections import defaultdict
+import ioda_conv_ncio as iconv
 
 
 class trak(object):
@@ -77,110 +79,77 @@ class trak(object):
 
         return
 
-    def _to_nlocs(self):
+    def to_ioda(self):
         '''
-        Selectively (e.g. salinity, temperature) convert odata into idata
+        Selectively convert odata into idata.
         idata is the IODA required data structure
         '''
-
-        # idata is the dictionary containing IODA friendly data structure
-        idata = self.odata
-
-        # Diff. between ob. time and time in the file (hrs)!
-        for i in range(self.odata['n_obs']):
-            dtg = datetime.strptime(self.odata['ob_dtg'][i], '%Y%m%d%H%M')
-            idata['ob_dtg'][i] = (dtg - self.date).total_seconds()/3600.
-
-        idata['nlocs'] = len(idata['ob_dtg'])
-
-        self.idata = idata
-
-        return
-
-    def to_ioda(self):
 
         if self.odata['n_obs'] <= 0:
             print('No trak observations for IODA!')
             return
 
-        self._to_nlocs()
+        locationKeyList = [
+            ("latitude", "float"),
+            ("longitude", "float"),
+            ("date_time", "string")
+        ]
 
-        ncid = netcdf.netcdf_file(self.filename + '.nc', mode='w')
+        AttrData = {
+            'odb_version': 1,
+            'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+        }
 
-        ncid.createDimension('nlocs', self.idata['nlocs'])  # no. of obs per var type
-        ncid.createDimension('nrecs', 1)  # no. of track obs
-        ncid.createDimension('nvars', 1)  # no. of variables
-        ncid.createDimension('nobs', 1*self.idata['nlocs'])  # total no. of obs
+        writer = iconv.NcWriter(self.filename+'.nc', [], locationKeyList)
 
-        longitudes = ncid.createVariable('longitude@MetaData', 'f4', ('nlocs',))
-        longitudes.units = 'degrees_east'
+        # idata is the dictionary containing IODA friendly data structure
+        idata = defaultdict(lambda: defaultdict(dict))
 
-        latitudes = ncid.createVariable('latitude@MetaData', 'f4', ('nlocs',))
-        latitudes.units = 'degrees_north'
+        var1Name = 'sea_surface_temperature'
+        val1Key = var1Name, writer.OvalName()
+        err1Key = var1Name, writer.OerrName()
+        qc1Key = var1Name, writer.OqcName()
 
-        times = ncid.createVariable('time@MetaData', 'f4', ('nlocs',))
-        times.long_name = 'observation time from date_time'
-        times.units = 'hours'
-        times.description = 'why does this have to be with a reference to, why not absolute?'
+        var2Name = 'sea_surface_salinity'
+        val2Key = var2Name, writer.OvalName()
+        err2Key = var2Name, writer.OerrName()
+        qc2Key = var2Name, writer.OqcName()
 
-        sal = ncid.createVariable('sea_surface_salinity@ObsValue', 'f4', ('nlocs',))
-        sal.units = 'g/kg'
-        sal.description = ''
+        var3Name = 'sea_surface_zonal_wind'
+        val3Key = var3Name, writer.OvalName()
+        err3Key = var3Name, writer.OerrName()
+        qc3Key = var3Name, writer.OqcName()
 
-        sal_errs = ncid.createVariable(
-            'sea_surface_salinity@ObsError', 'f4', ('nlocs',))
-        sal_errs.units = '(g/kg)'
-        sal_errs.description = 'Standard deviation of observation error'
+        var4Name = 'sea_surface_meriodional_wind'
+        val4Key = var4Name, writer.OvalName()
+        err4Key = var4Name, writer.OerrName()
+        qc4Key = var4Name, writer.OqcName()
 
-        sst = ncid.createVariable(
-            'sea_surface_temperature@ObsValue', 'f4', ('nlocs',))
-        sst.units = 'degree_celcius'
-        sst.description = ''
+        for n in range(self.odata['n_obs']):
 
-        sst_errs = ncid.createVariable(
-            'sea_surface_temperature@ObsError', 'f4', ('nlocs',))
-        sst_errs.units = '(degree_celcius)'
-        sst_errs.description = 'Standard deviation of observation error'
+            lat = self.odata['ob_lat'][n]
+            lon = self.odata['ob_lon'][n]
+            dtg = datetime.strptime(self.odata['ob_dtg'][n], '%Y%m%d%H%M')
 
-        u = ncid.createVariable(
-            'sea_surface_zonal_wind@ObsValue', 'f4', ('nlocs',))
-        u.units = 'm/s'
-        u.description = ''
+            locKey = lat, lon, dtg.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        u_errs = ncid.createVariable(
-            'sea_surface_zonal_wind@ObsError', 'f4', ('nlocs',))
-        u_errs.units = '(m/s)'
-        u_errs.description = 'Standard deviation of observation error'
+            idata[0][locKey][val1Key] = self.odata['ob_sst'][n]
+            idata[0][locKey][err1Key] = 1.0
+            idata[0][locKey][qc1Key] = self.odata['ob_qc_sst'][n]
 
-        v = ncid.createVariable(
-            'sea_surface_meridional_wind@ObsValue', 'f4', ('nlocs',))
-        v.units = 'm/s'
-        v.description = ''
+            idata[0][locKey][val2Key] = self.odata['ob_sal'][n]
+            idata[0][locKey][err2Key] = 1.0
+            idata[0][locKey][qc2Key] = self.odata['ob_qc_sal'][n]
 
-        v_errs = ncid.createVariable(
-            'sea_surface_meridional_wind@ObsError', 'f4', ('nlocs',))
-        v_errs.units = '(m/s)'
-        v_errs.description = 'Standard deviation of observation error'
+            idata[0][locKey][val3Key] = self.odata['ob_uuu'][n]
+            idata[0][locKey][err3Key] = 1.0
+            idata[0][locKey][qc3Key] = self.odata['ob_qc_vel'][n]
 
-        ncid.date_time = int(datetime.strftime(self.date, '%Y%m%d%H%M')[0:10])
+            idata[0][locKey][val4Key] = self.odata['ob_vvv'][n]
+            idata[0][locKey][err4Key] = 1.0
+            idata[0][locKey][qc4Key] = self.odata['ob_qc_vel'][n]
 
-        longitudes[:] = np.asarray(self.idata['ob_lon'], dtype=np.float32)
-        latitudes[:] = np.asarray(self.idata['ob_lat'], dtype=np.float32)
-        times[:] = np.asarray(self.idata['ob_dtg'], dtype=np.float32)
-
-        sal[:] = np.asarray(self.idata['ob_sal'], dtype=np.float32)
-        sal_errs[:] = 1.0
-
-        sst[:] = np.asarray(self.idata['ob_sst'], dtype=np.float32)
-        sst_errs[:] = 1.0
-
-        u[:] = np.asarray(self.idata['ob_uuu'], dtype=np.float32)
-        u_errs[:] = 1.0
-
-        v[:] = np.asarray(self.idata['ob_vvv'], dtype=np.float32)
-        v_errs[:] = 1.0
-
-        ncid.close()
+        writer.BuildNetcdf(idata, AttrData)
 
         return
 
@@ -195,7 +164,7 @@ if __name__ == '__main__':
         '-n', '--name', help='name of the binary GODAE track file (path)',
         type=str, required=True)
     parser.add_argument(
-        '-d', '--date', help='file date', type=str, required=True)
+        '-d', '--date', help='file date', type=str, metavar='YYYYMMDDHH', required=True)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Update GODAE converters to use IODA NcWriter.

Notes:

Some variable names, that are too long, are truncated in the NetCDF file; e.g. `sea_surface_temperature` appears as `sea_surface_temperat`, `sea_surface_zonal_wind` appears as `sea_surface_zonal_wi`.  This is due to the limited length of the character array in the NcWriter.

ioda_conv_ncio is not python 3.6 compatible and the scripts were tested with python 2.7.