### PR TITLE
Change variable name to match ufo

### DIFF
--- a/src/ODB2/Definitions/MO_amsua_Definition.yaml
+++ b/src/ODB2/Definitions/MO_amsua_Definition.yaml
@@ -40,8 +40,8 @@ column_variables:
     satellite_id: satellite_identifier
     sat_zenith_angle: zenith
     sat_azimuth_angle: azimuth
-    solar_zenith_angle: solar_zenith
-    solar_azimuth_angle: solar_azimuth
+    sol_zenith_angle: solar_zenith
+    sol_azimuth_angle: solar_azimuth
     scan_position: scanpos
     height: surface_height
 
@@ -146,8 +146,8 @@ location_key:
   date_time: string
   sat_zenith_angle: float
   sat_azimuth_angle: float
-  solar_zenith_angle: float
-  solar_azimuth_angle: float
+  sol_zenith_angle: float
+  sol_azimuth_angle: float
   scan_position: integer
   height: float
 


### PR DESCRIPTION
Needed to change the variable names "solar_zenith/azimuth_angle" to "sol_zenith/azimuth_angle" in order to match the UFO operator code. This will need to be changed back if/when we go through and correct all non-CF variable names in UFO.