### PR TITLE
Update repo Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ioda-converters
 
-The intended way to use this repository is to install in /usr/local by default, and if you cannot write into /usr/local use the CMAKE_INSTALL_PREFIX to install in your home directory. Run the scripts from the place they are installed, not the source directory. That way the scripts can reference each other without providing a path.
+The intended way to use this repository is to install in `/usr/local` by default, and if you cannot write into `/usr/local` use the CMAKE_INSTALL_PREFIX to install in your home directory. Run the scripts from the place they are installed, not the source directory. That way the scripts can reference each other without providing a path.
 
 For example,
+
 **ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file**
+
 **make install**
 
 ## bufr2nc

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Definition YAML files currently created and tested:
 * Met Office Radiosonde
 * Met Office Aircraft
 * Met Office AMSU-A from atovs report
+* ECMWF Radiosonde
+* ECMWF Aircraft
 
 ## odbapi2json
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 The intended way to use this repository is to install in /usr/local by default, and if you cannot write into /usr/local use the CMAKE_INSTALL_PREFIX to install in your home directory. Run the scripts from the place they are installed, not the source directory. That way the scripts can reference each other without providing a path.
 
 For example,
-
-**ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file
-
-make install**
+**ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file**
+**make install**
 
 ## bufr2nc
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ioda-converters
 
+The intended way to use this repository is to install in /usr/local by default, and if you cannot write into /usr/local use the CMAKE_INSTALL_PREFIX to install in your home directory. Run the scripts from the place they are installed, not the source directory. That way the scripts can reference each other without providing a path.
+
+For example,
+ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file
+make install
+
 ## bufr2nc
 
 Python script, bufr2nc.py, for converting BUFR to netCDF4. bufr2nc is built upon the py-ncepbufr package.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 The intended way to use this repository is to install in /usr/local by default, and if you cannot write into /usr/local use the CMAKE_INSTALL_PREFIX to install in your home directory. Run the scripts from the place they are installed, not the source directory. That way the scripts can reference each other without providing a path.
 
 For example,
-ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file
-make install
+
+**ecbuild -DCMAKE_INSTALL_PREFIX=$HOME/tools  path_to_top_level_cmakelists_file
+
+make install**
 
 ## bufr2nc
 


### PR DESCRIPTION
After seeing that Anna had the same trouble running one of the scripts in this repo that I had a while back, I thought it would be good to add some clarification on how to install the scripts to the Readme file.

I also updated the Readme section regarding the odbapi2nc.py script, which should have been done in the same pull request that added the new ECMWF YAML files.