### PR TITLE
Add option to copy bias-corrected obs value

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The marine converters all take the following format, with some converters taking
 
 Python script, odbapi2nc.py, for converting Met Office or ECMWF ODB2 files to netCDF4 files formatted for use by IODA.
 
-Usage: odbapi2nc.py [-h] [-c] [-q] [-t] [-v] input_odb2 definition_yaml output_netcdf
+Usage: odbapi2nc.py [-h] [-c] [-q] [-t] [-v] [-b] input_odb2 definition_yaml output_netcdf
 
 Definition YAML files currently created and tested:
 * Met Office Radiosonde

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -1,8 +1,7 @@
 list( APPEND programs
   odbapi2nc.py
   odbapi2json.py
-  var_convert.py
-  DESTINATION bin)
+  var_convert.py)
 
 COPY_FILES( "${programs}" ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/bin )
 

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -4,6 +4,14 @@ list( APPEND programs
   var_convert.py
   DESTINATION bin)
 
+COPY_FILES( "${programs}" ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/bin )
+
+install (PROGRAMS
+  odbapi2nc.py
+  odbapi2json.py
+  var_convert.py
+  DESTINATION bin)
+
 ecbuild_add_test( TARGET iodaconv_met-office_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh

--- a/src/ODB2/odbapi2nc.py
+++ b/src/ODB2/odbapi2nc.py
@@ -91,6 +91,8 @@ ap.add_argument("-t", "--trace", action="store_true",
                 help="Print trace statements")
 ap.add_argument("-v", "--convertvars", action="store_true",
                 help="Convert relative_humidity to specific_humidity and output both")
+ap.add_argument("-b", "--usecorvalue", action="store_true",
+                help="Copy 'corvalue' column (bias-corrected value) instead of 'obsvalue' column")
 
 MyArgs = ap.parse_args()
 
@@ -102,6 +104,7 @@ ClobberOfile = MyArgs.clobber
 qcFilter = MyArgs.qcfilter
 Trace = MyArgs.trace
 ConvertVars = MyArgs.convertvars
+UseCorvalue = MyArgs.usecorvalue
 
 # Check files
 BadArgs = False
@@ -183,6 +186,11 @@ selectColumns.append("datum_status.active")
 selectColumns.append("datum_status.passive")
 selectColumns.append("datum_status.rejected")
 selectColumns.append("datum_status.blacklisted")
+
+if UseCorvalue:
+    selectColumns.append("corvalue")
+    if Trace:
+        print "Copying corvalue column (bias-corrected) value instead of obsvalue column."
 
 # The columns above are always selected.
 # Next we add the columns that are required by the variables
@@ -273,10 +281,11 @@ dsRejectedIndex = selectColumns.index("datum_status.rejected")
 dsBlacklistIndex = selectColumns.index("datum_status.blacklisted")
 dateIndex = selectColumns.index(date_s)
 timeIndex = selectColumns.index(time_s)
-obsvalueIndex = selectColumns.index("obsvalue")
 obs_errorIndex = selectColumns.index("obs_error")
 varnoIndex = selectColumns.index("varno")
 vertcoRef1Index = selectColumns.index(vertco_reference_1_s)
+
+obsvalueIndex = selectColumns.index("corvalue") if UseCorvalue else selectColumns.index("obsvalue")
 
 rowCount = 0
 


### PR DESCRIPTION
We discovered that Met Office ODB2 reports contain a column called 'corvalue' which sometimes contains a bias-corrected observation value. This PR adds an option to the odbapi2nc import script that will allow users to import this bias-corrected value ('corvalue' column) instead of the un-corrected obs value ('obsvalue' column) if desired.

Also, while working on this enhancement, a problem was discovered with the ODB2 directory CMakeLists.txt file that was causing the ODB2 scripts to not get installed. (Not sure when this got broken since it used to work.) This is also fixed.