### PR TITLE
Feature/ctests marine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.nc filter=lfs diff=lfs merge=lfs -text
 *.nc4 filter=lfs diff=lfs merge=lfs -text
+*.bin filter=lfs diff=lfs merge=lfs -text
 src/ncep/xx120 filter=lfs diff=lfs merge=lfs -text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ include_directories( ${IODACONV_INCLUDE_DIRS} ${IODACONV_EXTRA_INCLUDE_DIRS} )
 include( iodaconv_extra_macros )
 add_subdirectory( src )
 add_subdirectory( tools )
+add_subdirectory( test )
 
 if(ECBUILD_INSTALL_FORTRAN_MODULES)
   install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )

--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -83,8 +83,8 @@ class NcWriter(object):
         self._ndatetime = 20
 
         # default fill values
-        self._defaultF4 = np.float32(np.abs(netCDF4.default_fillvals['f4']))
-        self._defaultI4 = np.int32(np.abs(netCDF4.default_fillvals['i4']))
+        self._defaultF4 = np.abs(netCDF4.default_fillvals['f4'])
+        self._defaultI4 = np.abs(netCDF4.default_fillvals['i4'])
 
         # Names assigned to record number (location metadata)
         self._rec_num_name = "record_number"
@@ -357,7 +357,7 @@ class NcWriter(object):
             else:
                 print('Warning: VarType',VarType,' not in float, int, str for:',ObsVarList[o])
 	        continue
-            ObsVars[ObsVarList[o]] = np.full((self._nvars, self._nlocs), defaultval)
+            ObsVars[ObsVarList[o]] = np.full((self._nvars, self._nlocs), defaultval,dtype=defaultval.dtype)
 
         LocMdata = OrderedDict()
         for i in range(len(self._loc_key_list)):

--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -83,8 +83,8 @@ class NcWriter(object):
         self._ndatetime = 20
 
         # default fill values
-        self._defaultF4 = np.abs(netCDF4.default_fillvals['f4'])
-        self._defaultI4 = np.abs(netCDF4.default_fillvals['i4'])
+        self._defaultF4 = np.float32(np.abs(netCDF4.default_fillvals['f4']))
+        self._defaultI4 = np.int32(np.abs(netCDF4.default_fillvals['i4']))
 
         # Names assigned to record number (location metadata)
         self._rec_num_name = "record_number"

--- a/src/marine/hgodas_sst2ioda.py
+++ b/src/marine/hgodas_sst2ioda.py
@@ -79,10 +79,10 @@ if __name__ == '__main__':
         description=('Read CPC Hybrid-GODAS sst files and convert'
                      ' to IODA format')
     )
-    parser.add_argument('-i',
+    parser.add_argument('-i', '--input',
                         help="name of HGODAS profile input file",
                         type=str, required=True)
-    parser.add_argument('-o',
+    parser.add_argument('-o', '--output',
                         help="name of ioda output file",
                         type=str, required=True)
     parser.add_argument('-d', '--date',

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,143 @@
+# (C) Copyright 2019 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+################################################################################
+# IODA-CONVERTER tests
+################################################################################
+
+list( APPEND test_input
+  testinput/gds2_sst_l2p.nc
+  testinput/gds2_sst_l3u.nc
+  testinput/godae_prof.bin
+  testinput/godae_ship.bin
+  testinput/godae_trak.bin
+  testinput/rads_adt.nc
+  testinput/smap_sss_rss.nc
+  testinput/hgodas_insitu.nc
+  testinput/hgodas_sst.nc
+)
+
+list( APPEND test_output
+  testoutput/gds2_sst_l2p.nc
+  testoutput/gds2_sst_l3u.nc
+  testoutput/godae_prof.nc
+  testoutput/godae_ship.nc
+  testoutput/godae_trak.nc
+  testoutput/rads_adt.nc
+  testoutput/smap_sss_rss.nc
+  testoutput/hgodas_insitu.nc
+  testoutput/hgodas_sst.nc
+)
+
+# create test directories and make links to the input files
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testoutput)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testrun)
+foreach(FILENAME ${test_input} ${test_output} iodaconv_comp.sh)
+    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
+endforeach(FILENAME)
+
+
+#===============================================================================
+# The following tests use nccmp to check the difference between the output
+#  file, and the reference copy of what the ouput file should look like.
+# The first argument to the script, wrapped in quotes, is the command to execute
+#  the ioda converter.
+# The second argument is the name of the output file to compare (one copy to be
+#  created in testrun/ by the converter, and one copy already present in in
+#  testoutput/)
+#===============================================================================
+
+#===============================================================================
+# Marine converters
+#===============================================================================
+
+ecbuild_add_test( TARGET test_iodaconv_gds2_sst_l2p
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/gds2_sst2ioda.py
+                       -i testinput/gds2_sst_l2p.nc
+                       -o testrun/gds2_sst_l2p.nc
+                       -d 2018041512
+                       -t 0.5"
+                      gds2_sst_l2p.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_gds2_sst_l3u
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/gds2_sst2ioda.py
+                       -i testinput/gds2_sst_l3u.nc
+                       -o testrun/gds2_sst_l3u.nc
+                       -d 2018041512
+                       -t 0.5"
+                      gds2_sst_l3u.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_smap_sss
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/smap_sss2ioda.py
+                       -i testinput/smap_sss_rss.nc
+                       -o testrun/smap_sss_rss.nc
+                       -d 2018041512"
+                      smap_sss_rss.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_rads_adt
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/rads_adt2ioda.py
+                       -i testinput/rads_adt.nc
+                       -o testrun/rads_adt.nc
+                       -d 2018041512"
+                      rads_adt.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_godae_prof
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/godae_profile2ioda.py
+                       -i testinput/godae_prof.bin
+                       -o testrun/godae_prof.nc
+                       -d 1998092212"
+                      godae_prof.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_godae_ship
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+		              ARGS "${CMAKE_BINARY_DIR}/bin/godae_ship2ioda.py
+                       -i testinput/godae_ship.bin
+                       -o testrun/godae_ship.nc
+                       -d 1998090112"
+                      godae_ship.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_godae_trak
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+		              ARGS "${CMAKE_BINARY_DIR}/bin/godae_trak2ioda.py
+                       -i testinput/godae_trak.bin
+                       -o testrun/godae_trak.nc
+                       -d 2004070812"
+                      godae_trak.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_hgodas_insitu
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+		              ARGS "${CMAKE_BINARY_DIR}/bin/hgodas_insitu2ioda.py
+                       -i testinput/hgodas_insitu.nc
+                       -o testrun/hgodas_insitu.nc
+                       -d 2018041512"
+                      hgodas_insitu.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_hgodas_sst
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS "${CMAKE_BINARY_DIR}/bin/hgodas_sst2ioda.py
+                       -i testinput/hgodas_sst.nc
+                       -o testrun/hgodas_sst.nc
+                       -d 2018041512"
+                      hgodas_sst.nc)
+
+#===============================================================================
+#===============================================================================

--- a/test/iodaconv_comp.sh
+++ b/test/iodaconv_comp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# use nccmp to compare the output of a ioda-converter
+#
+# argument 1: the command to run the ioda converter
+# argument 2: the filename to test
+
+$1 && \
+nccmp testrun/$2 testoutput/$2 -d -m -g -f -S

--- a/test/testinput/gds2_sst_l2p.nc
+++ b/test/testinput/gds2_sst_l2p.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f61f92dd71fc63a481804c5933d2c9c03aaa055fd643c58e2126ac6f79eee46
+size 64648

--- a/test/testinput/gds2_sst_l3u.nc
+++ b/test/testinput/gds2_sst_l3u.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f06b673aa031d7f664f4d8e3f4e4a42b5e8345eb9cbcc201634ec5773b193bc
+size 63217

--- a/test/testinput/godae_prof.bin
+++ b/test/testinput/godae_prof.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a55c7825c9d734e0a8894e6718a2b0d4fd182513d3c5f3c90ce8c53c20af39da
+size 10428

--- a/test/testinput/godae_ship.bin
+++ b/test/testinput/godae_ship.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69499222300b1054b44507fc7c8197f945fc1b6849593e3cea9a40a927a47d5a
+size 77167

--- a/test/testinput/godae_trak.bin
+++ b/test/testinput/godae_trak.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e827ab91dba847b18a4855df61b295cc9a1554973dba9fbf081aeaa84506c086
+size 7350

--- a/test/testinput/hgodas_insitu.nc
+++ b/test/testinput/hgodas_insitu.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0087702d9f8dd55c9224a932c6a4f87a2c10d826b16999a5a9160a84ba62fa82
+size 4724

--- a/test/testinput/hgodas_sst.nc
+++ b/test/testinput/hgodas_sst.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f527be03c65704c3e8d035c88bfbc1adb52a10759deb30683cb86c2ed6b2be1
+size 35644

--- a/test/testinput/rads_adt.nc
+++ b/test/testinput/rads_adt.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f667adb295b372d968bfb85e429ebdadc194afbaf6b13a8245750fbde6f97ab0
+size 6884

--- a/test/testinput/smap_sss_rss.nc
+++ b/test/testinput/smap_sss_rss.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e18c7629fe7601a17a7704c9a8f5b1157b0300c6b5c48b97d4426a9c4ed8a9fe
+size 55955

--- a/test/testoutput/gds2_sst_l2p.nc
+++ b/test/testoutput/gds2_sst_l2p.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edb5c0116b00d7f0d800eca3e307aca0e1084cd5e7a3890b1fb346307f3f2145
+size 20048

--- a/test/testoutput/gds2_sst_l3u.nc
+++ b/test/testoutput/gds2_sst_l3u.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:297c3af82ebcf6fabec125070bcf25be34da30f78823ec67bd59128097bc0fc1
+size 22920

--- a/test/testoutput/godae_prof.nc
+++ b/test/testoutput/godae_prof.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24ed48503b59dec945a16be4c70a17db70c734dd0d8d9f7f6c1c8b5c2d3b1cdf
+size 21865

--- a/test/testoutput/godae_ship.nc
+++ b/test/testoutput/godae_ship.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d39ea06ed00054a993227cb51f72c509f78e356b44f0632a6ce6f9ad68f049bd
+size 67036

--- a/test/testoutput/godae_trak.nc
+++ b/test/testoutput/godae_trak.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e33fe04a7c4d5af361f051baf3c161b96c2895c994971be12a8efa0b2f8d9e1f
+size 22454

--- a/test/testoutput/hgodas_insitu.nc
+++ b/test/testoutput/hgodas_insitu.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f502ef3c7291961decc4366b42e6c81c1f7d15ef0526c4c6dba622b483a076e4
+size 22899

--- a/test/testoutput/hgodas_sst.nc
+++ b/test/testoutput/hgodas_sst.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:288bff0320f5919e2e81f5c1a89cd93be1a0a5c1d8a41b9de06e0b98f6239c1a
+size 22126

--- a/test/testoutput/rads_adt.nc
+++ b/test/testoutput/rads_adt.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:717ccd96636f7b281781356c96baf042a02c5dc30ea4ab417437b4bd4112aae0
+size 19074

--- a/test/testoutput/smap_sss_rss.nc
+++ b/test/testoutput/smap_sss_rss.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cfb6aacde436397503aaca13ab7f23b71d2adbd03c12a25936ce4b5135c1f21
+size 15344


### PR DESCRIPTION
ctests using nccmp are added for the marine ioda-converters. To be used as a template for other people to add their own ctests. nccmp is assumed to already be available on the system.

I've shrunk the marine input files down a lot, each file is on the order of 10-50Kb