### PR TITLE
 TabError: inconsistent use of tabs and spaces in indentation at line 314

### DIFF
--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -311,7 +311,7 @@ class NcWriter(object):
 
         # Walk through the structure and get counts so arrays
         # can be preallocated, and variable numbers can be assigned
-	ObsVarList = []
+        ObsVarList = []
         ObsVarExamples = []
         VMName = []
         VMData = {}


### PR DESCRIPTION
Somehow the tabs and spaces had been screwed at line 314 of ioda_conv_ncio.py, therefore it was failing. 
