### PR TITLE
provide correct path to the central ioda-converter pycodestyle file. …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ if( HAVE_ODB_API )
   list( APPEND IODACONV_EXTRA_LIBRARIES     Odb    )
 endif()
 
+# Location of .pycodestyle for norm checking within IODA-converters
+set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+
 ################################################################################
 # Sources
 ################################################################################

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -19,4 +19,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_odb2_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )

--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -22,4 +22,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_gsi-ncdiag_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -21,4 +21,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )

--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -26,4 +26,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_marine_coding_norms
                   TYPE
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )

--- a/src/ncep/CMakeLists.txt
+++ b/src/ncep/CMakeLists.txt
@@ -18,4 +18,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_ncep_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -16,4 +16,4 @@ install (PROGRAMS
 ecbuild_add_test( TARGET iodaconv_utils_coding_norms
                   TYPE
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )


### PR DESCRIPTION
…CMAKE_SOURCE_DIR points to the root of the CMake tree, which is the base of the bundle if ioda-converters are included inside a bundle.

closes #157 

Change-Id: I61eb0f7ed76f376e9a93c2d77515e0878010c90d