### PR TITLE
bugfix/pgm-inst-lists

### DIFF
--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -11,9 +11,7 @@ SET_TARGETS_DEPS( "${programs}"
 add_custom_target( odb2_scripts ALL DEPENDS ${odb2_scripts_deps} )
 
 install (PROGRAMS
-  odbapi2nc.py
-  odbapi2json.py
-  var_convert.py
+  ${programs}
   DESTINATION bin)
 
 ecbuild_add_test( TARGET iodaconv_odb2_coding_norms

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -13,10 +13,7 @@ SET_TARGETS_DEPS( "${programs}"
 add_custom_target( lib_python_scripts ALL DEPENDS ${lib_python_scripts_deps} )
 
 install (PROGRAMS
-  ioda_conv_ncio.py
-  collect_sources.py
-  run-pyflakes.py
-  run-mccabe.py
+  ${programs}
   DESTINATION bin)
 
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,5 +9,5 @@ SET_TARGETS_DEPS( "${programs}"
 add_custom_target( tools_scripts ALL DEPENDS ${tools_scripts_deps} )
 
 install (PROGRAMS
-  lint.sh
+  ${programs}
   DESTINATION bin)


### PR DESCRIPTION
I noticed a couple CMakeLists.txt that had repeated the elements of the ${programs} variable instead of using the ${programs} variable in the cmake install(PROGRAMS ... DESTINATION bin) command. This was causing the lib-python/orddicsts.py module to not be installed in the $CMAKE_INSTALL_PREFIX/bin directory. 