### PR TITLE
Add concatenation of GeoVaLs and Fix bug in combine_conv.py

### DIFF
--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -12,6 +12,7 @@ list( APPEND programs
   proc_gsi_ncdiag.py
   test_gsidiag.py
   combine_conv.py
+  combine_geoval.py
   subset_files.py
 )
 

--- a/src/gsi-ncdiag/combine_conv.py.in
+++ b/src/gsi-ncdiag/combine_conv.py.in
@@ -122,12 +122,12 @@ def concat_ioda(FileList, OutFile):
         DataVarIdx.append(tmpvaridx)
     DataVarData = np.vstack(DataVarData)
     DataVarIdx = np.vstack(DataVarIdx)
-    DataVarUnique = np.ones((len(DataVarData),len(idx)))*np.abs(nc.default_fillvals['f4'])
+    DataVarUnique = np.ones((len(DataVarData), len(idx)))*np.abs(nc.default_fillvals['f4'])
     for ii, jj in np.ndindex(DataVarData.shape):
-        i = DataVarIdx[ii,jj]
+        i = DataVarIdx[ii, jj]
         j = inv[jj]
-        if DataVarData[ii,jj] != nc.default_fillvals['i4'] and DataVarData[ii,jj] != np.abs(nc.default_fillvals['f4']):
-            DataVarUnique[i,j] = DataVarData[ii,jj]
+        if DataVarData[ii, jj] != nc.default_fillvals['i4'] and DataVarData[ii, jj] != np.abs(nc.default_fillvals['f4']):
+            DataVarUnique[i, j] = DataVarData[ii, jj]
     # set up things for the Ncwriter
     ridx = np.argwhere(np.array(MetaVars) == 'record_number@MetaData')[0][0]
     Recs = set(MetaVarUnique[ridx, :].astype('int'))

--- a/src/gsi-ncdiag/combine_conv.py.in
+++ b/src/gsi-ncdiag/combine_conv.py.in
@@ -75,7 +75,6 @@ def concat_ioda(FileList, OutFile):
                 MetaInAll[v] = False
             ncf.close()
     # extract metadata and generate a numpy array
-    print(MetaVars)
     MetaVarData = []
     MetaVarUnique = []
     for v in MetaVars:
@@ -94,16 +93,19 @@ def concat_ioda(FileList, OutFile):
             tmpvardata = np.hstack(tmpvardata)
         MetaVarData.append(tmpvardata)
     MetaVarData = np.vstack(MetaVarData)
-    MetaVarUnique, idx = np.unique(MetaVarData, return_index=True, axis=1)
+    MetaVarUnique, idx, inv, cnt = np.unique(MetaVarData, return_index=True, return_inverse=True, return_counts=True, axis=1)
     # grab variables to write out
     DataVarData = []
+    DataVarIdx = []
     for idx2, v in enumerate(DataVars):
         tmpvardata = []
+        tmpvaridx = []
         for f in FileList:
             ncf = nc.Dataset(f, mode='r')
             try:
                 tmpdata = ncf.variables[v][:]
                 tmpvardata.append(tmpdata)
+                tmpvaridx.append(np.ones_like(tmpdata).astype(int)*int(idx2))
             except KeyError:
                 tmpdata = np.ones_like(ncf.variables['record_number@MetaData'][:]).astype(DataVType[idx2])
                 if DataVType[idx2] == np.int32:
@@ -111,12 +113,21 @@ def concat_ioda(FileList, OutFile):
                 else:
                     tmpdata = tmpdata * np.abs(nc.default_fillvals['f4'])
                 tmpvardata.append(tmpdata)
+                tmpvaridx.append(np.ones_like(tmpdata).astype(int)*int(idx2))
             validtime = dt.datetime.strptime(str(ncf.getncattr('date_time')), "%Y%m%d%H")
             ncf.close()
         tmpvardata = np.hstack(tmpvardata)
+        tmpvaridx = np.hstack(tmpvaridx)
         DataVarData.append(tmpvardata)
+        DataVarIdx.append(tmpvaridx)
     DataVarData = np.vstack(DataVarData)
-    DataVarUnique = DataVarData[..., idx]
+    DataVarIdx = np.vstack(DataVarIdx)
+    DataVarUnique = np.ones((len(DataVarData),len(idx)))*np.abs(nc.default_fillvals['f4'])
+    for ii, jj in np.ndindex(DataVarData.shape):
+        i = DataVarIdx[ii,jj]
+        j = inv[jj]
+        if DataVarData[ii,jj] != nc.default_fillvals['i4'] and DataVarData[ii,jj] != np.abs(nc.default_fillvals['f4']):
+            DataVarUnique[i,j] = DataVarData[ii,jj]
     # set up things for the Ncwriter
     ridx = np.argwhere(np.array(MetaVars) == 'record_number@MetaData')[0][0]
     Recs = set(MetaVarUnique[ridx, :].astype('int'))

--- a/src/gsi-ncdiag/combine_geoval.py.in
+++ b/src/gsi-ncdiag/combine_geoval.py.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # combine_geoval.py
-# combine geovals from multiple input files into 
+# combine geovals from multiple input files into
 # one output file with matching corresponding locations
 # and missing data where applicable
 
@@ -15,6 +15,7 @@ import datetime as dt
 MetaVars = [
     'latitude', 'longitude', 'time', 'surface_pressure',
 ]
+
 
 def concat_geoval(FileList, OutFile, ForceAll):
     VarNames = []
@@ -32,7 +33,6 @@ def concat_geoval(FileList, OutFile, ForceAll):
                 VarTypes.append(vtype)
                 VarDims.append(ncf.variables[key].shape)
         ncf.close()
-    print(VarNames)
     # extract metadata and generate a numpy array
     MetaVarData = []
     MetaVarUnique = []
@@ -67,8 +67,7 @@ def concat_geoval(FileList, OutFile, ForceAll):
                 else:
                     tmpdata = tmpdata * np.abs(nc.default_fillvals['f4'])
             try:
-                shp = tmpdata.shape[1] 
-                print(shp)
+                shp = tmpdata.shape[1]
                 tmpvardata2d.append(tmpdata)
                 if v not in Vars2D:
                     Vars2D.append(v)
@@ -108,21 +107,17 @@ def concat_geoval(FileList, OutFile, ForceAll):
     nco.createDimension("nlocs", nlocs)
     nco.createDimension("nlevs", nlevs)
     for ivar, var in enumerate(MetaVars):
-        print(var)
         var_out = nco.createVariable(var, "f4", ("nlocs", ))
         var_out[...] = MetaVarUnique[ivar, ...]
     for ivar, var in enumerate(Vars2D):
-        print('2d')
-        print(var)
         dims = ("nlocs", "nlevs")
-        var_out = nco.createVariable(var, VarTypes[ivar], dims) 
+        var_out = nco.createVariable(var, VarTypes[ivar], dims)
         var_out[...] = DataVarUnique2D[..., ivar]
     for ivar, var in enumerate(Vars1D):
-        print('1d')
-        print(var)
         dims = ("nlocs", )
-        var_out = nco.createVariable(var, VarTypes[ivar], dims) 
+        var_out = nco.createVariable(var, VarTypes[ivar], dims)
         var_out[...] = DataVarUnique1D[ivar, ...]
+
 
 ######################################################
 ######################################################
@@ -144,6 +139,6 @@ if __name__ == '__main__':
 
     FileList = args.input
     OutFile = args.output
-    ForceAll = args.forceall 
+    ForceAll = args.forceall
 
     concat_geoval(FileList, OutFile, ForceAll)

--- a/src/gsi-ncdiag/combine_geoval.py.in
+++ b/src/gsi-ncdiag/combine_geoval.py.in
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# combine_geoval.py
+# combine geovals from multiple input files into 
+# one output file with matching corresponding locations
+# and missing data where applicable
+
+import netCDF4 as nc
+import numpy as np
+import argparse
+import datetime as dt
+
+# the GeoVaLs script here is not as smart as the obs one
+# we will just assume that entries are repeated if they have
+# the same lat/lon/time tuple and that hopefully will work
+MetaVars = [
+    'latitude', 'longitude', 'time', 'surface_pressure',
+]
+
+def concat_geoval(FileList, OutFile, ForceAll):
+    VarNames = []
+    Vars2D = []
+    Vars1D = []
+    VarTypes = []
+    VarDims = []
+    # get lists of variables
+    for f in FileList:
+        ncf = nc.Dataset(f, mode='r')
+        for key, value in ncf.variables.items():
+            if key not in VarNames and key not in MetaVars:
+                VarNames.append(key)
+                vtype = ncf.variables[key].dtype
+                VarTypes.append(vtype)
+                VarDims.append(ncf.variables[key].shape)
+        ncf.close()
+    print(VarNames)
+    # extract metadata and generate a numpy array
+    MetaVarData = []
+    MetaVarUnique = []
+    for v in MetaVars:
+        tmpvardata = []
+        for f in FileList:
+            ncf = nc.Dataset(f, mode='r')
+            tmpdata = ncf.variables[v][:]
+            tmpvardata.append(tmpdata)
+            ncf.close()
+        tmpvardata = np.hstack(tmpvardata)
+        MetaVarData.append(tmpvardata)
+    MetaVarData = np.vstack(MetaVarData)
+    MetaVarUnique, idx, inv, cnts = np.unique(MetaVarData, return_index=True, return_inverse=True, return_counts=True, axis=1)
+    if ForceAll:
+        idx = np.arange(0, len(MetaVarData[0]))
+        MetaVarUnique = MetaVarData[..., idx]
+    # grab variables to write out
+    DataVarData1D = []
+    DataVarData2D = []
+    for idx2, v in enumerate(VarNames):
+        tmpvardata1d = []
+        tmpvardata2d = []
+        for f in FileList:
+            ncf = nc.Dataset(f, mode='r')
+            try:
+                tmpdata = ncf.variables[v][:]
+            except KeyError:
+                tmpdata = np.ones(VarDims[idx2]).astype(VarTypes[idx2])
+                if VarTypes[idx2] == np.int32:
+                    tmpdata = tmpdata * nc.default_fillvals['i4']
+                else:
+                    tmpdata = tmpdata * np.abs(nc.default_fillvals['f4'])
+            try:
+                shp = tmpdata.shape[1] 
+                print(shp)
+                tmpvardata2d.append(tmpdata)
+                if v not in Vars2D:
+                    Vars2D.append(v)
+            except IndexError:
+                tmpvardata1d.append(tmpdata)
+                if v not in Vars1D:
+                    Vars1D.append(v)
+            validtime = dt.datetime.strptime(str(ncf.getncattr('date_time')), "%Y%m%d%H")
+            ncf.close()
+        try:
+            tmpvardata1d = np.hstack(tmpvardata1d)
+            DataVarData1D.append(tmpvardata1d)
+        except ValueError:
+            pass
+        try:
+            tmpvardata2d = np.vstack(tmpvardata2d)
+            DataVarData2D.append(tmpvardata2d)
+        except ValueError:
+            pass
+    DataVarData1D = np.vstack(DataVarData1D)
+    DataVarUnique1D = DataVarData1D[..., idx]
+    DataVarData2D = np.dstack(DataVarData2D)
+    DataVarUnique2D = DataVarData2D[idx, ...]
+    print(MetaVarData.shape)
+    print(DataVarData1D.shape)
+    print(DataVarData2D.shape)
+    print(MetaVarUnique.shape)
+    print(DataVarUnique1D.shape)
+    print(DataVarUnique2D.shape)
+
+    # write out the output netCDF file and all of the concatenated fields
+    # note GeoVaLs doesn't use Ncwriter!
+    nco = nc.Dataset(OutFile, 'w', format='NETCDF4')
+    nco.setncattr("date_time", np.int32(validtime.strftime("%Y%m%d%H")))
+    nlocs = len(MetaVarUnique[0])
+    nlevs = len(DataVarData2D[0])
+    nco.createDimension("nlocs", nlocs)
+    nco.createDimension("nlevs", nlevs)
+    for ivar, var in enumerate(MetaVars):
+        print(var)
+        var_out = nco.createVariable(var, "f4", ("nlocs", ))
+        var_out[...] = MetaVarUnique[ivar, ...]
+    for ivar, var in enumerate(Vars2D):
+        print('2d')
+        print(var)
+        dims = ("nlocs", "nlevs")
+        var_out = nco.createVariable(var, VarTypes[ivar], dims) 
+        var_out[...] = DataVarUnique2D[..., ivar]
+    for ivar, var in enumerate(Vars1D):
+        print('1d')
+        print(var)
+        dims = ("nlocs", )
+        var_out = nco.createVariable(var, VarTypes[ivar], dims) 
+        var_out[...] = DataVarUnique1D[ivar, ...]
+
+######################################################
+######################################################
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Combine GeoVaLs in netCDF format into one output file',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-i', '--input', help='list of the input files to combine',
+        type=str, nargs='+', required=True)
+    parser.add_argument(
+        '-o', '--output', help='name of the output GeoVaLs file',
+        type=str, required=True, default=None)
+    parser.add_argument(
+        '-f', '--forceall', help='force all values and not remove duplicates',
+        action='store_true', required=False,)
+
+    args = parser.parse_args()
+
+    FileList = args.input
+    OutFile = args.output
+    ForceAll = args.forceall 
+
+    concat_geoval(FileList, OutFile, ForceAll)


### PR DESCRIPTION
Fixes bug in combine_conv that filtered out too many Tv observations (among other issues) with incorrect indexing.

Also adds combine_geoval.py which when using -f will simply concatenate all of the input GeoVaLs files (unique locations not working 100% correctly in this one, it's more difficult because of less metadata)