### PR TITLE
Bugfix/odb code norms

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,5 +1,5 @@
 [pycodestyle]
 count = False
-ignore = E226,E401,E402
+ignore = E226,E401,E402,W503,W504
 max-line-length = 160
 statistics = True

--- a/src/ODB2/.pycodestyle
+++ b/src/ODB2/.pycodestyle
@@ -1,5 +1,5 @@
 [pycodestyle]
 count = False
-ignore = E226,E401,E402
+ignore = E221,E222,E226,E401,E402,W503,W504
 max-line-length = 160
 statistics = True

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -5,6 +5,8 @@ list( APPEND programs
   odbapi2nc.py
   odbapi2json.py)
 
+set ( ODB2_PYCODESTYLE_CONFIG ${CMAKE_CURRENT_SOURCE_DIR} )
+
 SET_TARGETS_DEPS( "${libs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${PYIODACONV_BUILD_LIBDIR}
@@ -43,4 +45,4 @@ install( FILES
 ecbuild_add_test( TARGET iodaconv_odb2_coding_norms
                   TYPE SCRIPT
                   COMMAND ${CMAKE_BINARY_DIR}/bin/lint.sh
-                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${IODACONV_PYLINT_CFG_DIR} )
+                  ARGS ${CMAKE_CURRENT_SOURCE_DIR} ${ODB2_PYCODESTYLE_CONFIG} )

--- a/src/ODB2/odbapi2json.py.in
+++ b/src/ODB2/odbapi2json.py.in
@@ -147,7 +147,7 @@ while row is not None:
     varName = sondeVarnoDict[row.varno]
 
     profileKey = row.statid.rstrip(), anDateTimeString
-    #TODO: For now we convert pressure (vertco_reference_1) to hPa here. No units stored yet.
+    # TODO: For now we convert pressure (vertco_reference_1) to hPa here. No units stored yet.
     pressure = row.vertco_reference_1 / 100.0 if row.vertco_reference_1 is not None else IODA_MISSING_VAL
     locationKey = row.lat, row.lon, pressure, obsDateTimeString
     ovalKey = varName, ncOvalName
@@ -159,19 +159,19 @@ while row is not None:
     if qcVal is None:
         qcVal = IODA_MISSING_VAL
 
-    #Assignment code below is done this way for two reasons:
+    # Assignment code below is done this way for two reasons:
     # 1. Want to make sure all locations get into IODA, even if they only have
     #    missing values. (Preserve all the data we can.)
     # 2. There can be multiple entries in the file for each locationKey, but
     #    we can only keep one. So we choose an entry that is not null/missing, if present.
     if (ovalKey not in obsDataDictTree[profileKey][locationKey] or
-         obsDataDictTree[profileKey][locationKey][ovalKey] == IODA_MISSING_VAL):
+            obsDataDictTree[profileKey][locationKey][ovalKey] == IODA_MISSING_VAL):
         obsDataDictTree[profileKey][locationKey][ovalKey] = oval
     if (oerrKey not in obsDataDictTree[profileKey][locationKey] or
-         obsDataDictTree[profileKey][locationKey][oerrKey] == IODA_MISSING_VAL):
+            obsDataDictTree[profileKey][locationKey][oerrKey] == IODA_MISSING_VAL):
         obsDataDictTree[profileKey][locationKey][oerrKey] = oerr
     if (oqcKey not in obsDataDictTree[profileKey][locationKey] or
-         obsDataDictTree[profileKey][locationKey][oqcKey] == IODA_MISSING_VAL):
+            obsDataDictTree[profileKey][locationKey][oqcKey] == IODA_MISSING_VAL):
         obsDataDictTree[profileKey][locationKey][oqcKey] = qcVal
 
     # obsDataDictTree[profileKey][locationKey][ovalKey] = row.obsvalue
@@ -180,7 +180,7 @@ while row is not None:
 
     row = c.fetchone()
 
-#After all the data from the file is in the dictionary tree, populate "gaps" with IODA missing value.
+# After all the data from the file is in the dictionary tree, populate "gaps" with IODA missing value.
 for profileKey in obsDataDictTree:
     for locationKey in obsDataDictTree[profileKey]:
         for varName in sondeVarnoDict.values():
@@ -188,9 +188,9 @@ for profileKey in obsDataDictTree:
                 if (varName, varCat) not in obsDataDictTree[profileKey][locationKey]:
                     obsDataDictTree[profileKey][locationKey][varName, varCat] = IODA_MISSING_VAL
 
-#For now, we convert relative to specific humidity here.
-#This code should be removed eventually, as this is not the right place to convert variables.
-#print "statid,lat,lon,datetime,rh,rh_err,t,p,q,q_err"
+# For now, we convert relative to specific humidity here.
+# This code should be removed eventually, as this is not the right place to convert variables.
+# print "statid,lat,lon,datetime,rh,rh_err,t,p,q,q_err"
 for profileKey in obsDataDictTree:
     for locationKey in obsDataDictTree[profileKey]:
         if ("relative_humidity", ncOvalName) in obsDataDictTree[profileKey][locationKey]:
@@ -200,7 +200,7 @@ for profileKey in obsDataDictTree:
             t = obsDict.get(("air_temperature", ncOvalName))
             p = locationKey[2]
             if (t is not None and rh is not None and rh_err is not None and p is not None and
-            t != IODA_MISSING_VAL and rh != IODA_MISSING_VAL and rh_err != IODA_MISSING_VAL and p != IODA_MISSING_VAL):
+                    t != IODA_MISSING_VAL and rh != IODA_MISSING_VAL and rh_err != IODA_MISSING_VAL and p != IODA_MISSING_VAL):
                 q, q_err = var_convert.ConvertRelativeToSpecificHumidity(rh, rh_err, t, p)
 
                 obsDict[("specific_humidity", ncOvalName)] = q
@@ -210,12 +210,12 @@ for profileKey in obsDataDictTree:
                 obsDict[("specific_humidity", ncOvalName)] = IODA_MISSING_VAL
                 obsDict[("specific_humidity", ncOerrName)] = IODA_MISSING_VAL
             obsDict[("specific_humidity", ncOqcName)] = obsDict[("relative_humidity", ncOqcName)]
-                #print ",".join(map(lambda x: str(x), [profileKey[0],locationKey[0],locationKey[1],locationKey[3],rh,rh_err,t,p,q,q_err]))
+            # print ",".join(map(lambda x: str(x), [profileKey[0],locationKey[0],locationKey[1],locationKey[3],rh,rh_err,t,p,q,q_err]))
 
 # print "Top level len: ", len(obsDataDictTree)
 # print "Num Locations: ", len(obsDataDictTree[profileKey])
 
-#Construct new dictionary that we'll dump to JSON, that can then be imported to MongoDB if desired
+# Construct new dictionary that we'll dump to JSON, that can then be imported to MongoDB if desired
 t_val = []
 t_err = []
 t_qc = []
@@ -281,11 +281,10 @@ variables["eastward_wind"] = eastward_wind
 variables["northward_wind"] = northward_wind
 outputDict["variables"] = variables
 
-#print outputDict["latitude"]
+# print outputDict["latitude"]
 
 import json
 print str(json.dumps(outputDict, sort_keys=True, indent=4, separators=(',', ': ')))
 # f = open(jsonFname, "w")
 # print(json.dumps(outputDict, sort_keys=True, indent=4, separators=(',', ': ')), file=f)
 # f.close()
-

--- a/src/ODB2/odbapi2json.py.in
+++ b/src/ODB2/odbapi2json.py.in
@@ -136,13 +136,13 @@ while row is not None:
         refDateTimeString = anDateTimeString
     obsDateTimeString = ioda_conv_util.IntDateTimeToString(row.date, row.time)
     # Encode the 8 QC bitfields in the ODB API file into a single value for IODA
-    qcVal = (row.report_status_active * 128 +
-             row.report_status_passive * 64 +
-             row.report_status_rejected * 32 +
-             row.report_status_blacklisted * 16 +
-             row.datum_status_active * 8 +
-             row.datum_status_passive * 4 +
-             row.datum_status_rejected * 2 +
+    qcVal = (row.report_status_active      * 128 +
+             row.report_status_passive     *  64 +
+             row.report_status_rejected    *  32 +
+             row.report_status_blacklisted *  16 +
+             row.datum_status_active       *   8 +
+             row.datum_status_passive      *   4 +
+             row.datum_status_rejected     *   2 +
              row.datum_status_blacklisted)
     varName = sondeVarnoDict[row.varno]
 

--- a/src/ODB2/odbapi2json.py.in
+++ b/src/ODB2/odbapi2json.py.in
@@ -209,7 +209,7 @@ for profileKey in obsDataDictTree:
             else:
                 obsDict[("specific_humidity", ncOvalName)] = IODA_MISSING_VAL
                 obsDict[("specific_humidity", ncOerrName)] = IODA_MISSING_VAL
-            obsDict[("specific_humidity", ncOqcName)] = obsDict[("relative_humidity", ncOqcName)]
+                obsDict[("specific_humidity", ncOqcName)] = obsDict[("relative_humidity", ncOqcName)]
             # print ",".join(map(lambda x: str(x), [profileKey[0],locationKey[0],locationKey[1],locationKey[3],rh,rh_err,t,p,q,q_err]))
 
 # print "Top level len: ", len(obsDataDictTree)

--- a/src/ODB2/odbapi2json.py.in
+++ b/src/ODB2/odbapi2json.py.in
@@ -11,13 +11,13 @@ import ioda_conv_ncio as iconv
 import ioda_conv_util
 import var_convert
 
-#NOTE: As of December 11, 2018, the ODB API python package is built into the Singularity image and
+# NOTE: As of December 11, 2018, the ODB API python package is built into the Singularity image and
 #      put in /usr/local/lib/python2.7/dist-packages/odb, so the code below regarding the path
 #      is unneeded in that environment (but it doesn't hurt anything).
 #      If not in Singularity/Charliecloud, then note ODB API must be built on the system with the
 #      ENABLE_PYTHON flag on or else the python module won't be there.
 odbPythonPath = os.getenv('ODBPYTHONPATH', os.environ['HOME'] + '/projects/odb/install/lib/python2.7/site-packages/odb')
-#print odbPythonPath
+# print odbPythonPath
 
 try:
     sys.path.index(odbPythonPath)
@@ -33,7 +33,7 @@ ScriptName = os.path.basename(sys.argv[0])
 
 # Parse command line
 ap = argparse.ArgumentParser()
-#ap.add_argument("obs_type", help="observation type")
+# ap.add_argument("obs_type", help="observation type")
 ap.add_argument("input_odb2", help="path to input Met Office ODB API file")
 ap.add_argument("output_netcdf", help="path to output netCDF4 file")
 ap.add_argument("-c", "--clobber", action="store_true",
@@ -43,7 +43,7 @@ ap.add_argument("-q", "--qcfilter", action="store_true",
 
 MyArgs = ap.parse_args()
 
-#ObsType = MyArgs.obs_type
+# ObsType = MyArgs.obs_type
 Odb2Fname = MyArgs.input_odb2
 jsonFname = MyArgs.output_netcdf
 ClobberOfile = MyArgs.clobber
@@ -70,23 +70,23 @@ if (BadArgs):
     sys.exit(2)
 
 sondeVarnoDict = {
-    2:  "air_temperature",
-    3:  "eastward_wind",
-    4:  "northward_wind",
+    2: "air_temperature",
+    3: "eastward_wind",
+    4: "northward_wind",
     29: "relative_humidity"
 }
 
 recordKeyList = [
-    ( "station_id", "string" ),
-    ( "analysis_date_time", "string" )
-    ]
+    ("station_id", "string"),
+    ("analysis_date_time", "string")
+]
 
 locationKeyList = [
-    ( "latitude", "float" ),
-    ( "longitude", "float" ),
-    ( "air_pressure", "float" ),
-    ( "date_time", "string" )
-    ]
+    ("latitude", "float"),
+    ("longitude", "float"),
+    ("air_pressure", "float"),
+    ("date_time", "string")
+]
 
 # Instantiate a netcdf writer object, and get the obs data names from
 # the writer object.
@@ -94,15 +94,15 @@ nc_writer = iconv.NcWriter(jsonFname, recordKeyList, locationKeyList)
 
 ncOvalName = nc_writer.OvalName()
 ncOerrName = nc_writer.OerrName()
-ncOqcName  = nc_writer.OqcName()
+ncOqcName = nc_writer.OqcName()
 
-IODA_MISSING_VAL = 1.0e9 #IODA converts any value larger than 1e8 to "Missing Value"
+IODA_MISSING_VAL = 1.0e9  # IODA converts any value larger than 1e8 to "Missing Value"
 varCategories = [ncOvalName, ncOerrName, ncOqcName]
 
-#The top-level dictionary is keyed by (statid, andate, antime), which uniquely identifiies a profile (balloon launch).
-#The second-level dictionary is keyed by (lat, lon, pressure, date, time), which uniquely identifies a location
-#The third (bottom) level is keyed by a variable name and contains the value of the variable at the location.
-obsDataDictTree = defaultdict(lambda:defaultdict(dict))
+# The top-level dictionary is keyed by (statid, andate, antime), which uniquely identifiies a profile (balloon launch).
+# The second-level dictionary is keyed by (lat, lon, pressure, date, time), which uniquely identifies a location
+# The third (bottom) level is keyed by a variable name and contains the value of the variable at the location.
+obsDataDictTree = defaultdict(lambda: defaultdict(dict))
 
 fetchColumns = 'statid, andate, antime, stalt, lon, lat, vertco_reference_1, date, time, obsvalue, varno, obs_error, ' \
                'report_status.active, report_status.passive, report_status.rejected, report_status.blacklisted, ' \
@@ -112,8 +112,8 @@ FetchRow = namedtuple('FetchRow', tupleNames)
 conn = odb.connect(Odb2Fname)
 c = conn.cursor()
 
-#vertco_type=1 indicates pressure
-#vertco_type=11 indicates "derived pressure", which is a pressure value calculated from airplane flight level
+# vertco_type=1 indicates pressure
+# vertco_type=11 indicates "derived pressure", which is a pressure value calculated from airplane flight level
 #               instead of directly measured. Derived pressure is not present in radiosonde files, but is in
 #               aircraft files. We are treating both types identically in this code.
 sql = "select " + fetchColumns + " from \"" + Odb2Fname + "\"" + \
@@ -121,10 +121,10 @@ sql = "select " + fetchColumns + " from \"" + Odb2Fname + "\"" + \
     "(varno=2 or varno=3 or varno=4 or varno=29)"
 if qcFilter:
     sql += " and report_status.active=1 and report_status.passive=0 and report_status.rejected=0 and" \
-    " report_status.blacklisted=0 and datum_status.active=1 and datum_status.passive=0 and datum_status.rejected=0" \
-    " and datum_status.blacklisted=0"
+           " report_status.blacklisted=0 and datum_status.active=1 and datum_status.passive=0 and datum_status.rejected=0" \
+           " and datum_status.blacklisted=0"
 sql += ';'
-#print sql
+# print sql
 
 c.execute(sql)
 row = c.fetchone()
@@ -135,14 +135,14 @@ while row is not None:
     if (refDateTimeString == "UnSeT"):
         refDateTimeString = anDateTimeString
     obsDateTimeString = ioda_conv_util.IntDateTimeToString(row.date, row.time)
-    #Encode the 8 QC bitfields in the ODB API file into a single value for IODA
-    qcVal = (row.report_status_active      * 128 +
-             row.report_status_passive     *  64 +
-             row.report_status_rejected    *  32 +
-             row.report_status_blacklisted *  16 +
-             row.datum_status_active       *   8 +
-             row.datum_status_passive      *   4 +
-             row.datum_status_rejected     *   2 +
+    # Encode the 8 QC bitfields in the ODB API file into a single value for IODA
+    qcVal = (row.report_status_active * 128 +
+             row.report_status_passive * 64 +
+             row.report_status_rejected * 32 +
+             row.report_status_blacklisted * 16 +
+             row.datum_status_active * 8 +
+             row.datum_status_passive * 4 +
+             row.datum_status_rejected * 2 +
              row.datum_status_blacklisted)
     varName = sondeVarnoDict[row.varno]
 

--- a/src/ODB2/odbapi2nc.py.in
+++ b/src/ODB2/odbapi2nc.py.in
@@ -12,7 +12,7 @@ import ioda_conv_ncio as iconv
 import ioda_conv_util
 import var_convert
 
-#NOTE: As of December 11, 2018, the ODB API python package is built into the Singularity image and
+# NOTE: As of December 11, 2018, the ODB API python package is built into the Singularity image and
 #      put in /usr/local/lib/python2.7/dist-packages/odb, so the code below regarding the path
 #      is unneeded in that environment (but it doesn't hurt anything).
 #      As of March 28, 2019, the ODB API python module is in the python path when you load the
@@ -20,7 +20,7 @@ import var_convert
 #      If not using these environments, then note ODB API must be built on the system with the
 #      ENABLE_PYTHON flag on or else the python module won't be there.
 odbPythonPath = os.getenv('ODBPYTHONPATH', os.environ['HOME'] + '/projects/odb/install/lib/python2.7/site-packages/odb')
-#print odbPythonPath
+# print odbPythonPath
 
 try:
     sys.path.index(odbPythonPath)
@@ -42,7 +42,8 @@ date_time_s = "datetime"
 float_s = "float"
 string_s = "string"
 varnoVertco_s = "USE_VERTCO"
-IODA_MISSING_VAL = 1.0e9 #IODA converts any value larger than 1e8 to "Missing Value"
+IODA_MISSING_VAL = 1.0e9  # IODA converts any value larger than 1e8 to "Missing Value"
+
 
 def CreateKeyTuple(keyDefinitionDict, row, selectColumns, ColumnVarDict, VertcoVarDict):
     returnKey = []

--- a/src/ODB2/odbapi2nc.py.in
+++ b/src/ODB2/odbapi2nc.py.in
@@ -63,7 +63,7 @@ def CreateKeyTuple(keyDefinitionDict, row, selectColumns, ColumnVarDict, VertcoV
         elif keyVariableName == date_time_s:
             keyVariableValue = ioda_conv_util.IntDateTimeToString(row[selectColumns.index(date_s)], row[selectColumns.index(time_s)])
 
-        if keyVariableValue == None:
+        if keyVariableValue is None:
             if keyDefinitionDict[keyVariableName] == float_s:
                 keyVariableValue = IODA_MISSING_VAL
             elif keyDefinitionDict[keyVariableName] == string_s:
@@ -74,6 +74,7 @@ def CreateKeyTuple(keyDefinitionDict, row, selectColumns, ColumnVarDict, VertcoV
         returnKey.append(keyVariableValue)
     returnKey = tuple(returnKey)
     return returnKey
+
 
 ###################################################################################
 # MAIN
@@ -98,7 +99,7 @@ ap.add_argument("-b", "--usecorvalue", action="store_true",
 
 MyArgs = ap.parse_args()
 
-#ObsType = MyArgs.obs_type
+# ObsType = MyArgs.obs_type
 Odb2Fname = MyArgs.input_odb2
 DefFname = MyArgs.input_def
 NetcdfFname = MyArgs.output_netcdf
@@ -161,13 +162,13 @@ if Trace:
 
 # Define strings that act as keys in yaml definition file.
 # The passed yaml file must use these strings, of course.
-#yamlColumnVariables = 'column_variables'
+# yamlColumnVariables = 'column_variables'
 # yamlVarnoVariables = 'varno_variables'
 # yamlVertcoVariables = 'vertco_variables'
-yamlRecordKey ='record_key'
+yamlRecordKey = 'record_key'
 yamlLocationKey = 'location_key'
 
-#print columnVariableDict
+# print columnVariableDict
 
 # Assemble list of columns to select
 selectColumns = []
@@ -241,25 +242,25 @@ nc_writer = iconv.NcWriter(NetcdfFname, recordKeyList, locationKeyList)
 
 ncOvalName = nc_writer.OvalName()
 ncOerrName = nc_writer.OerrName()
-ncOqcName  = nc_writer.OqcName()
+ncOqcName = nc_writer.OqcName()
 
 varCategories = [ncOvalName, ncOerrName, ncOqcName]
 
-#The top-level dictionary is keyed by the fields in recordKeyList, which uniquely identifiies a record.
-#The second-level dictionary is keyed by the fields in locationKeyList, which uniquely identifies a location
-#The third (bottom) level is keyed by a variable name and contains the value of the variable at the location.
-obsDataDictTree = defaultdict(lambda:defaultdict(dict))
+# The top-level dictionary is keyed by the fields in recordKeyList, which uniquely identifiies a record.
+# The second-level dictionary is keyed by the fields in locationKeyList, which uniquely identifies a location
+# The third (bottom) level is keyed by a variable name and contains the value of the variable at the location.
+obsDataDictTree = defaultdict(lambda: defaultdict(dict))
 
 conn = odb.connect(Odb2Fname)
 c = conn.cursor()
 
 # Construct the entire sql statement
 sql = "select " + selectColumnsString + " from \"" + Odb2Fname + "\"" + \
-    " where (" + vertcoTypeSqlString +") and (" + varnoSqlString + ")"
+    " where (" + vertcoTypeSqlString + ") and (" + varnoSqlString + ")"
 if qcFilter:
     sql += " and report_status.active=1 and report_status.passive=0 and report_status.rejected=0 and" \
-    " report_status.blacklisted=0 and datum_status.active=1 and datum_status.passive=0 and datum_status.rejected=0" \
-    " and datum_status.blacklisted=0"
+           " report_status.blacklisted=0 and datum_status.active=1 and datum_status.passive=0 and datum_status.rejected=0" \
+           " and datum_status.blacklisted=0"
 sql += ';'
 
 if Trace:
@@ -271,8 +272,8 @@ c.execute(sql)
 row = c.fetchone()
 refDateTimeString = None
 
-#Defining these sql row indexes outside the main loop prevents new objects
-#from being created for each one every iteration.
+# Defining these sql row indexes outside the main loop prevents new objects
+# from being created for each one every iteration.
 rsActiveIndex = selectColumns.index("report_status.active")
 rsPassiveIndex = selectColumns.index("report_status.passive")
 rsRejectedIndex = selectColumns.index("report_status.rejected")
@@ -300,18 +301,18 @@ while row is not None:
     if (refDateTimeString is None):
         refDateTimeString = ioda_conv_util.IntDateTimeToString(row[selectColumns.index(andate_s)], row[selectColumns.index(antime_s)])
     obsDateTimeString = ioda_conv_util.IntDateTimeToString(row[dateIndex], row[timeIndex])
-    #Encode the 8 QC bitfields in the ODB2 file into a single value for IODA
-    #Flip the "active" flags so that zero is always the "good" value for all the flags,
-    #and a qcVal of zero indicates a good datum.
+    # Encode the 8 QC bitfields in the ODB2 file into a single value for IODA
+    # Flip the "active" flags so that zero is always the "good" value for all the flags,
+    # and a qcVal of zero indicates a good datum.
     notReportStatusActive = 0 if row[rsActiveIndex] else 1
     notDatumStatusActive = 0 if row[dsActiveIndex] else 1
     qcVal = (notReportStatusActive * 128 +
-             row[rsPassiveIndex]   *  64 +
-             row[rsRejectedIndex]  *  32 +
-             row[rsBlacklistIndex] *  16 +
-             notDatumStatusActive  *   8 +
-             row[dsPassiveIndex]   *   4 +
-             row[dsRejectedIndex]  *   2 +
+             row[rsPassiveIndex] * 64 +
+             row[rsRejectedIndex] * 32 +
+             row[rsBlacklistIndex] * 16 +
+             notDatumStatusActive * 8 +
+             row[dsPassiveIndex] * 4 +
+             row[dsRejectedIndex] * 2 +
              row[dsBlacklistIndex])
 
     # For conventional obs, varName is usually found using only varno.
@@ -342,19 +343,19 @@ while row is not None:
     if qcVal is None:
         qcVal = IODA_MISSING_VAL
 
-    #Assignment code below is done this way for two reasons:
+    # Assignment code below is done this way for two reasons:
     # 1. Want to make sure all locations get into IODA, even if they only have
     #    missing values. (Preserve all the data we can.)
     # 2. There can be multiple entries in the file for each locationKey, but
     #    we can only keep one. So we choose an entry that is not null/missing, if present.
     if (ovalKey not in obsDataDictTree[recordKey][locationKey] or
-         obsDataDictTree[recordKey][locationKey][ovalKey] == IODA_MISSING_VAL):
+            obsDataDictTree[recordKey][locationKey][ovalKey] == IODA_MISSING_VAL):
         obsDataDictTree[recordKey][locationKey][ovalKey] = oval
     if (oerrKey not in obsDataDictTree[recordKey][locationKey] or
-         obsDataDictTree[recordKey][locationKey][oerrKey] == IODA_MISSING_VAL):
+            obsDataDictTree[recordKey][locationKey][oerrKey] == IODA_MISSING_VAL):
         obsDataDictTree[recordKey][locationKey][oerrKey] = oerr
     if (oqcKey not in obsDataDictTree[recordKey][locationKey] or
-         obsDataDictTree[recordKey][locationKey][oqcKey] == IODA_MISSING_VAL):
+            obsDataDictTree[recordKey][locationKey][oqcKey] == IODA_MISSING_VAL):
         obsDataDictTree[recordKey][locationKey][oqcKey] = qcVal
 
     row = c.fetchone()
@@ -362,7 +363,7 @@ while row is not None:
 if Trace:
     print "Finished reading file. Now populating missing values."
 
-#After all the data from the file is in the dictionary tree, populate "gaps" with IODA missing value.
+# After all the data from the file is in the dictionary tree, populate "gaps" with IODA missing value.
 for recordKey in obsDataDictTree:
     for locationKey in obsDataDictTree[recordKey]:
         for varno in varnoVariableDict:
@@ -380,8 +381,8 @@ for recordKey in obsDataDictTree:
 if Trace:
     print "Finished populating missing values."
 
-#For now, we allow converting relative humidity (varno=29) to specific humidity here.
-#This code should be removed eventually, as this is not the right place to convert variables.
+# For now, we allow converting relative humidity (varno=29) to specific humidity here.
+# This code should be removed eventually, as this is not the right place to convert variables.
 if ConvertVars and (29 in varnoVariableDict):
     if Trace:
         print "Converting relative humidity to specific humidity."
@@ -389,8 +390,8 @@ if ConvertVars and (29 in varnoVariableDict):
     specific_humidity_s = "specific_humidity"
     temperature_s = "temperature"
 
-    #In order to retrieve the pressure value from the location key, we need to know
-    #what position of the tuple it's in.
+    # In order to retrieve the pressure value from the location key, we need to know
+    # what position of the tuple it's in.
     pressureIndex = -1
     for index, varName in enumerate(importDef[yamlLocationKey]):
         if varName == "air_pressure":
@@ -406,7 +407,7 @@ if ConvertVars and (29 in varnoVariableDict):
                 t = obsDict.get((temperature_s, ncOvalName))
                 p = locationKey[pressureIndex]
                 if (t is not None and rh is not None and rh_err is not None and p is not None and
-                t != IODA_MISSING_VAL and rh != IODA_MISSING_VAL and rh_err != IODA_MISSING_VAL and p != IODA_MISSING_VAL):
+                        t != IODA_MISSING_VAL and rh != IODA_MISSING_VAL and rh_err != IODA_MISSING_VAL and p != IODA_MISSING_VAL):
                     q, q_err = var_convert.ConvertRelativeToSpecificHumidity(rh, rh_err, t, p)
 
                     obsDict[(specific_humidity_s, ncOvalName)] = q
@@ -428,9 +429,9 @@ if Trace:
 # version 1 netcdf file. The reference date time string won't be necessary when
 # we switch to the version 2 netcdf file.
 AttrData = {
-  'odb_version' : 2,
-  'date_time_string' : refDateTimeString
-   }
+    'odb_version': 2,
+    'date_time_string': refDateTimeString
+}
 
 (ObsVars, RecMdata, LocMdata, VarMdata) = nc_writer.ExtractObsData(obsDataDictTree)
 nc_writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)

--- a/src/ODB2/odbapi2nc.py.in
+++ b/src/ODB2/odbapi2nc.py.in
@@ -416,7 +416,7 @@ if ConvertVars and (29 in varnoVariableDict):
                 else:
                     obsDict[(specific_humidity_s, ncOvalName)] = IODA_MISSING_VAL
                     obsDict[(specific_humidity_s, ncOerrName)] = IODA_MISSING_VAL
-                obsDict[(specific_humidity_s, ncOqcName)] = obsDict[(relative_humidity_s, ncOqcName)]
+                    obsDict[(specific_humidity_s, ncOqcName)] = obsDict[(relative_humidity_s, ncOqcName)]
     if Trace:
         print "Finished humidity conversion."
 

--- a/src/ODB2/odbapi2nc.py.in
+++ b/src/ODB2/odbapi2nc.py.in
@@ -307,12 +307,12 @@ while row is not None:
     notReportStatusActive = 0 if row[rsActiveIndex] else 1
     notDatumStatusActive = 0 if row[dsActiveIndex] else 1
     qcVal = (notReportStatusActive * 128 +
-             row[rsPassiveIndex] * 64 +
-             row[rsRejectedIndex] * 32 +
-             row[rsBlacklistIndex] * 16 +
-             notDatumStatusActive * 8 +
-             row[dsPassiveIndex] * 4 +
-             row[dsRejectedIndex] * 2 +
+             row[rsPassiveIndex]   *  64 +
+             row[rsRejectedIndex]  *  32 +
+             row[rsBlacklistIndex] *  16 +
+             notDatumStatusActive  *   8 +
+             row[dsPassiveIndex]   *   4 +
+             row[dsRejectedIndex]  *   2 +
              row[dsBlacklistIndex])
 
     # For conventional obs, varName is usually found using only varno.

--- a/src/ODB2/var_convert.py
+++ b/src/ODB2/var_convert.py
@@ -4,6 +4,7 @@
 
 from math import exp
 
+
 def ConvertRelativeToSpecificHumidity(rh, rh_err, t, p):
     T_KELVIN = 273.15
     ES_ALPHA = 6.112
@@ -12,19 +13,17 @@ def ConvertRelativeToSpecificHumidity(rh, rh_err, t, p):
     GAS_CONSTANT = 287.0
     GAS_CONSTANT_V = 461.6
     HUNDRED = 100.0
-    
+
     rdOverRv = GAS_CONSTANT / GAS_CONSTANT_V
     rdOverRv1 = 1.0 - rdOverRv
     t_celcius = t - T_KELVIN
-    #p = p / HUNDRED # Convert from Pa to hPa
+    # p = p / HUNDRED # Convert from Pa to hPa
 
-    #Calculate saturation vapor pressure
+    # Calculate saturation vapor pressure
     es = ES_ALPHA * exp(ES_BETA * t_celcius / (t_celcius + ES_GAMMA))
-    #Calculate saturation specific humidity
+    # Calculate saturation specific humidity
     qs = rdOverRv * es / (p - rdOverRv1 * es)
-    #Calculate specific humidity
+    # Calculate specific humidity
     q = qs * rh / HUNDRED
     q_err = qs * rh_err / HUNDRED
     return q, q_err
-
-


### PR DESCRIPTION
This PR gets the odb2_coding_norms test to pass. I had to add two warnings (W503 and W504) to the ignore list in the .pycodestyle in order to get this working. These warnings are about binary operators being at the end or beginning of lines. autopep8 cannot fix these, plus the pycodestyle documentation says that these are ignored by default since there is not consensus on whether these should be warnings at all. Hopefully, adding these will be acceptable for our needs.

@svahl991, I checked to make sure these changes don't impact the results from the file test you created. 