### PR TITLE
Required 'feature/use_pressure' changes.

### DIFF
--- a/src/ODB2/Definitions/MO_amsua_Definition.yaml
+++ b/src/ODB2/Definitions/MO_amsua_Definition.yaml
@@ -38,16 +38,12 @@ column_variables:
     longitude: lon
     latitude: lat
     satellite_id: satellite_identifier
-    sat_zenith_angle: zenith
-    sat_azimuth_angle: azimuth
-    sol_zenith_angle: solar_zenith
-    sol_azimuth_angle: solar_azimuth
+    sensor_zenith_angle: zenith
+    sensor_azimuth_angle: azimuth
+    solar_zenith_angle: solar_zenith
+    solar_azimuth_angle: solar_azimuth
     scan_position: scanpos
     height: surface_height
-
-#TODO: change "sat_zenith_angle" to either "sensor_zenith_angle" or
-#      "platform_zenith_angle", which are CF standard names.
-#      Only using "sat_zenith_angle" for now b/c that's what UFO has.
 
 # vertco_variables are read from the vertco_reference_1 column
 # when the vertco_type column has the specified value.
@@ -144,10 +140,10 @@ location_key:
   latitude: float
   longitude: float
   datetime: string
-  sat_zenith_angle: float
-  sat_azimuth_angle: float
-  sol_zenith_angle: float
-  sol_azimuth_angle: float
+  sensor_zenith_angle: float
+  sensor_azimuth_angle: float
+  solar_zenith_angle: float
+  solar_azimuth_angle: float
   scan_position: integer
   height: float
 

--- a/src/ODB2/odbapi2json.py.in
+++ b/src/ODB2/odbapi2json.py.in
@@ -147,8 +147,7 @@ while row is not None:
     varName = sondeVarnoDict[row.varno]
 
     profileKey = row.statid.rstrip(), anDateTimeString
-    # TODO: For now we convert pressure (vertco_reference_1) to hPa here. No units stored yet.
-    pressure = row.vertco_reference_1 / 100.0 if row.vertco_reference_1 is not None else IODA_MISSING_VAL
+    pressure = row.vertco_reference_1 if row.vertco_reference_1 is not None else IODA_MISSING_VAL
     locationKey = row.lat, row.lon, pressure, obsDateTimeString
     ovalKey = varName, ncOvalName
     oerrKey = varName, ncOerrName

--- a/src/ODB2/odbapi2nc.py.in
+++ b/src/ODB2/odbapi2nc.py.in
@@ -39,10 +39,6 @@ def CreateKeyTuple(keyDefinitionDict, row, selectColumns, ColumnVarDict, VertcoV
         elif keyVariableName in VertcoVarDict:
             if row[selectColumns.index(vertco_type_s)] == VertcoVarDict[keyVariableName]:
                 keyVariableValue = row[selectColumns.index(vertco_reference_1_s)]
-                # If we're returning a pressure value, we divide by 100 to convert from Pa to hPa.
-                # vertco_type=1 ==> pressure, vertco_type=11 ==> derived pressure (from aircraft altitude)
-                if (VertcoVarDict[keyVariableName] == 1 or VertcoVarDict[keyVariableName] == 11) and keyVariableValue is not None:
-                    keyVariableValue /= 100.0
         elif keyVariableName == analysis_date_time_s:
             keyVariableValue = ioda_conv_util.IntDateTimeToString(row[selectColumns.index(andate_s)], row[selectColumns.index(antime_s)])
         elif keyVariableName == date_time_s:

--- a/src/ODB2/var_convert.py
+++ b/src/ODB2/var_convert.py
@@ -17,7 +17,7 @@ def ConvertRelativeToSpecificHumidity(rh, rh_err, t, p):
     rdOverRv = GAS_CONSTANT / GAS_CONSTANT_V
     rdOverRv1 = 1.0 - rdOverRv
     t_celcius = t - T_KELVIN
-    p = p / HUNDRED # Convert from Pa to hPa
+    p = p / HUNDRED  # Convert from Pa to hPa
 
     # Calculate saturation vapor pressure
     es = ES_ALPHA * exp(ES_BETA * t_celcius / (t_celcius + ES_GAMMA))

--- a/src/ODB2/var_convert.py
+++ b/src/ODB2/var_convert.py
@@ -17,7 +17,7 @@ def ConvertRelativeToSpecificHumidity(rh, rh_err, t, p):
     rdOverRv = GAS_CONSTANT / GAS_CONSTANT_V
     rdOverRv1 = 1.0 - rdOverRv
     t_celcius = t - T_KELVIN
-    # p = p / HUNDRED # Convert from Pa to hPa
+    p = p / HUNDRED # Convert from Pa to hPa
 
     # Calculate saturation vapor pressure
     es = ES_ALPHA * exp(ES_BETA * t_celcius / (t_celcius + ES_GAMMA))

--- a/test/testoutput/odb_sonde_16019.nc4
+++ b/test/testoutput/odb_sonde_16019.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56b254fffb389eefbca3bcb5a3448629b6a0bb0b7b0aac9574e05483b8471412
+oid sha256:163c1c03b0df287c91c0d8aac68a6af95e2d1b6683739485f0aec0ed46906237
 size 33146


### PR DESCRIPTION
These changes to the ODB2-to-IODA converter are required due to the changes coming in PR's of the same branch name in IODA and [UFO](https://github.com/JCSDA/ufo/pull/327).

ODB2 files store pressure in Pa units, and the script no longer converts that to hPa when creating the corresponding IODA file.

Also, the CRTM variable names have been updated to reflect the change by UFO to using the CF names.