### PR TITLE
bugfix/abs-fillval

### DIFF
--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -75,8 +75,8 @@ class NcWriter(object):
         self._ndatetime = 20
 
         # default fill values
-        self._defaultF4 = np.abs(netCDF4.default_fillvals['f4'])
-        self._defaultI4 = np.abs(netCDF4.default_fillvals['i4'])
+        self._defaultF4 = np.float32(netCDF4.default_fillvals['f4'])
+        self._defaultI4 = np.int32(netCDF4.default_fillvals['i4'])
 
         # Names assigned to record number (location metadata)
         self._rec_num_name = "record_number"

--- a/test/testoutput/hgodas_insitu.nc
+++ b/test/testoutput/hgodas_insitu.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68e25d00c36bcd8090ba3f2f44d539539ef2c6aa056225a35c37817c00db3518
-size 21112
+oid sha256:63ce050d4e4bc150682da63d3be330a3d8e7b1c02f4a2f56b8e7c908a4db3171
+size 23156


### PR DESCRIPTION
This PR removes the np.abs() calls with netcdf default fill value arguments in the ioda_conv_ncio.py library. The np.abs() is no longer needed since the IodaIO reader now recognizes the netcdf default fill values.