### PR TITLE
bugfix/ext-obs-nan

### DIFF
--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -392,6 +392,8 @@ class NcWriter(object):
                 LocMdata[self._rec_num_name][LocNum-1] = RecNum
 
                 for VarKey, VarVal in LocDict.items():
+                    if (type(VarVal) in [np.ma.core.MaskedConstant]):
+                        VarVal = self._defaultF4
                     ObsVars[VarKey][LocNum-1] = VarVal
 
         return (ObsVars, RecMdata, LocMdata, VarMdata)


### PR DESCRIPTION
This PR fixes a problem that sometimes caused nans to appear in the output netcdf file. This fix works on @CoryMartin-NOAA ozone obs sample, and I'm wondering if this could be related to the Infinity values @HamidehGMAO saw recently in the GMI obs file.