### PR TITLE
add obsdiag file containing diagnostics output from GSI for QC development in UFO

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -364,7 +364,7 @@ units_values = {
     'top_level_pressure': 'Pa',
     'bottom_level_pressure': 'Pa',
     'tropopause_pressure': 'Pa',
-    'brightness_temperature_jacobian_surface_temperature': '1' ,
+    'brightness_temperature_jacobian_surface_temperature': '1',
     'brightness_temperature_jacobian_surface_emissivity': 'K',
     'brightness_temperature_jacobian_air_temperature': '1',
     'brightness_temperature_jacobian_humidity_mixing_ratio': 'K/g/Kg ',
@@ -865,7 +865,7 @@ class Radiances:
         nlocs = int(self.nobs / nchans)
         chanlist = chan_number
 
-        # get data 
+        # get data
         for var in self.df.variables.values():
             vname = var.name
             if vname in obsdiag_metadata_dict.keys():
@@ -875,35 +875,35 @@ class Radiances:
                 vdata = vdata[::self.nchans]
                 var_out[:] = vdata
             elif vname in obsdiag_vars.keys():
-              # print("toObsdiag: var.shape = ", var.shape)
+                # print("toObsdiag: var.shape = ", var.shape)
                 if (len(var.dimensions) == 1):
                     dims = ("nlocs",)
                     for c in range(len(chanlist)):
-                       var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
-                       idx = chan_indx == c+1
-                       if (np.sum(idx) == 0):
-                          print("No matching observations for:")
-                          print(value)
-                          continue
-                       var_out = ncout.createVariable(var_name, var.dtype, dims)
-                       vdata = var[:]
-                       vdata = vdata[idx]
-                       var_out[:] = vdata
+                        var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
+                        idx = chan_indx == c+1
+                        if (np.sum(idx) == 0):
+                            print("No matching observations for:")
+                            print(value)
+                            continue
+                        var_out = ncout.createVariable(var_name, var.dtype, dims)
+                        vdata = var[:]
+                        vdata = vdata[idx]
+                        var_out[:] = vdata
                 elif "_levels" in vname:
                     dims = ("nlocs", "nlevsp1")
                 else:
                     dims = ("nlocs", "nlevs")
                     for c in range(len(chanlist)):
-                       var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
-                       idx = chan_indx == c+1
-                       if (np.sum(idx) == 0):
-                          print("No matching observations for:")
-                          print(value)
-                          continue
-                       var_out = ncout.createVariable(var_name, var.dtype, dims)
-                       vdata = var[...]
-                       vdata = vdata[idx,...]
-                       var_out[...] = vdata
+                        var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
+                        idx = chan_indx == c+1
+                        if (np.sum(idx) == 0):
+                            print("No matching observations for:")
+                            print(value)
+                            continue
+                        var_out = ncout.createVariable(var_name, var.dtype, dims)
+                        vdata = var[...]
+                        vdata = vdata[idx, ...]
+                        var_out[...] = vdata
             else:
                 pass
         ncout.close()

--- a/src/gsi-ncdiag/proc_gsi_ncdiag.py.in
+++ b/src/gsi-ncdiag/proc_gsi_ncdiag.py.in
@@ -76,6 +76,7 @@ def run_oz_geo(ozfile, outdir):
     Diag.toGeovals(outdir)
     return 0
 
+
 def run_radiances_obsdiag(radfile, outdir):
     print("Processing run_radiances_obsdiag:")
     print("Processing:"+str(radfile))
@@ -190,7 +191,7 @@ if MyArgs.geovals_dir:
 # process obsdiag files
 if MyArgs.obsdiag_dir:
     ObsdiagDir = MyArgs.obsdiag_dir
-    # radiances only 
+    # radiances only
     radfiles = glob.glob(DiagDir+'/diag*')
     for radfile in radfiles:
         process = False

--- a/src/gsi-ncdiag/proc_gsi_ncdiag.py.in
+++ b/src/gsi-ncdiag/proc_gsi_ncdiag.py.in
@@ -19,6 +19,7 @@ def run_conv_obs(convfile, outdir, platforms):
 
 
 def run_radiances_obs(radfile, outdir):
+    print("Processing run_radiances_obs:")
     print("Processing:"+str(radfile))
     Diag = gsid.Radiances(radfile)
     Diag.read()
@@ -52,6 +53,7 @@ def run_conv_geo(convfile, outdir):
 
 
 def run_radiances_geo(radfile, outdir):
+    print("Processing run_radiances_geo:")
     print("Processing:"+str(radfile))
     Diag = gsid.Radiances(radfile)
     Diag.read()
@@ -74,6 +76,14 @@ def run_oz_geo(ozfile, outdir):
     Diag.toGeovals(outdir)
     return 0
 
+def run_radiances_obsdiag(radfile, outdir):
+    print("Processing run_radiances_obsdiag:")
+    print("Processing:"+str(radfile))
+    Diag = gsid.Radiances(radfile)
+    Diag.read()
+    Diag.toObsdiag(outdir)
+    return 0
+
 
 ScriptName = os.path.basename(sys.argv[0])
 
@@ -85,6 +95,8 @@ ap.add_argument("input_dir", help="Path to concatenated GSI diag files")
 ap.add_argument("-o", "--obs_dir",
                 help="Path to directory to output observations")
 ap.add_argument("-g", "--geovals_dir",
+                help="Path to directory to output observations")
+ap.add_argument("-d", "--obsdiag_dir",
                 help="Path to directory to output observations")
 
 MyArgs = ap.parse_args()
@@ -174,6 +186,19 @@ if MyArgs.geovals_dir:
                 process = True
         if process:
             res = obspool.apply_async(run_oz_geo, args=(radfile, GeoDir))
+
+# process obsdiag files
+if MyArgs.obsdiag_dir:
+    ObsdiagDir = MyArgs.obsdiag_dir
+    # radiances only 
+    radfiles = glob.glob(DiagDir+'/diag*')
+    for radfile in radfiles:
+        process = False
+        for p in gsid.rad_sensors:
+            if p in radfile:
+                process = True
+        if process:
+            res = obspool.apply_async(run_radiances_obsdiag, args=(radfile, ObsdiagDir))
 
 # process all in the same time, because sats with many channels are so slow...
 obspool.close()


### PR DESCRIPTION
Currently, there are geoval and obs files used in UFO for development.  To implement the capability of data quality control (QC) in UFO, an additional set of information such as Jacobians and layer optical depth from the observation operator is required from GSI.  The capability of converting, subset, and write this additional set information from GSI diagnostic file to a separate file (obsdiatg) is added.  