### PR TITLE
Fixed a bug in the n_vrsn variable to read 6 characters of the WMO si…

### DIFF
--- a/src/marine/godae_ship2ioda.py.in
+++ b/src/marine/godae_ship2ioda.py.in
@@ -73,7 +73,7 @@ class ship(object):
 
         if data['n_vrsn'] <= 2:
             print('verify ob_sign for version = %d' % data['n_vrsn'])
-            data['ob_sign'] = fh.read_record('>S7').astype('U7')
+            data['ob_sign'] = fh.read_record('S6').astype('U6')
         else:
             data['ob_sign'] = fh.read_record('>S7').astype('U7')
 


### PR DESCRIPTION
This PR addresses a bugfix in godae_ship2ioda.py.
The godae_ship2ioda.py converter was failing to convert the FNMOC ship data to ioda format and has bug in the n_vrsn variable related to reading the WMO sign number.
The original fortran code (ocn_obs.f) reads 6 characters of the WMO sign. 

The bug has been fixed and tested.
