### PR TITLE
Two bugs with emc_ice

### DIFF
--- a/src/marine/emc_ice2ioda.py.in
+++ b/src/marine/emc_ice2ioda.py.in
@@ -7,8 +7,6 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
 
-from orddicts import DefaultOrderedDict
-import ioda_conv_ncio as iconv
 from __future__ import print_function
 import sys
 import argparse
@@ -18,7 +16,8 @@ import dateutil.parser
 import numpy as np
 
 sys.path.append("@SCRIPT_LIB_PATH@")
-
+from orddicts import DefaultOrderedDict
+import ioda_conv_ncio as iconv
 
 class Observation(object):
 
@@ -62,7 +61,7 @@ class Observation(object):
                     np.array2string(
                         datein[i]), "%Y%m%d"), datetime.strptime(
                     np.array2string(
-                        timein[i]), "%H%M").time())
+                        timein[i]).zfill(4), "%H%M").time())
             locKey = lats[i], lons[i], obs_date.strftime("%Y-%m-%dT%H:%M:%SZ")
             self.data[0][locKey][valKey] = vals[i]
             self.data[0][locKey][errKey] = 0.1

--- a/src/marine/emc_ice2ioda.py.in
+++ b/src/marine/emc_ice2ioda.py.in
@@ -19,6 +19,7 @@ sys.path.append("@SCRIPT_LIB_PATH@")
 from orddicts import DefaultOrderedDict
 import ioda_conv_ncio as iconv
 
+
 class Observation(object):
 
     def __init__(self, filename, thin, date, writer):


### PR DESCRIPTION
The code had one bug and there was an issue with the time convention of the data. 

More specific: 
1. Loading the ioda-converter modules was transferred after appending the path.
2. The time convention was a four-digit integer, which is impossible for 12-9AM, making the  DateTime fail when 00:00. 

The code tested by converting successfully 30 days of observations. 