### PR TITLE
Add exising LD_LIBRARY_PATH to bash script

### DIFF
--- a/test/iodaconv_comp.sh
+++ b/test/iodaconv_comp.sh
@@ -5,7 +5,7 @@
 # argument 1: the command to run the ioda converter
 # argument 2: the filename to test
 
-export LD_LIBRARY_PATH=${CTEST_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${CTEST_LIBRARY_PATH}:${LD_LIBRARY_PATH}
 
 $1 && \
 nccmp testrun/$2 testoutput/$2 -d -m -g -f -S


### PR DESCRIPTION

So @travissluka and @mer-a-o - this is why the ioda-converters tests are failing in the intel containers.  Python wants to access the library ```libimf.so``` which is in the ```LD_LIBRARY_PATH```.  So, running the python scripts manually works fine but when the compare script runs them, it resets the paths and causes this error:
~~~~~
python: error while loading shared libraries: libimf.so: cannot open shared object file: No such file or directory
~~~~~
This bugfix fixes that so all ioda-converters tests now pass in the intel17 container.  I haven't tried yet with the intel 19 container.