### PR TITLE
Add capability to handle NCEP operational observations

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -37,6 +37,11 @@ conv_platforms = {
     "conv_gps": [
         'gps',
     ]
+#>>emily
+    "conv_sst": [
+        'sst',
+    ]
+#<<emily
 }
 
 # note in python range, last number is not used so second values are +1
@@ -58,7 +63,8 @@ conv_bufrtypes = {
     "rass": [126],
     "sfcship": [180, 183],
     "sfc": [181, 187],
-    "gps": [3, 4, 745],
+    "gps": [3, 4, 42, 43, 745, 825],  #emily
+    "sst": [181, 182, 183, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202], #emily sst
 }
 
 # LocKeyList = { 'gsiname':('IODAname','dtype')}
@@ -104,6 +110,7 @@ conv_varnames = {
     "q": ["specific_humidity"],
     "bend": ["bending_angle"],
     "refract": ["refractivity"],
+    "sst": ["sea_surface_temperature"],  #emily sst
 }
 
 conv_gsivarnames = {
@@ -114,7 +121,28 @@ conv_gsivarnames = {
     "q": ["Observation"],
     "bend": ["Observation"],
     "refract": ["Observation"],
+    "sst": ["Observation"],      #emily sst
 }
+
+#>>emily
+gsi_add_vars_allsky = {
+    'Observation_Type': 'ObsType',
+    'Prep_Use_Flag': 'PreUseFlag',
+    'Analysis_Use_Flag': 'GsiUseFlag',
+    'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
+    'Errinv_Adjust': 'GsiAdjustObsError',
+    'Errinv_Final': 'GsiFinalObsError',
+    'Forecast_adjusted': 'GsiHofXBc',
+    'Forecast_unadjusted': 'GsiHofX',
+    'Forecast_unadjusted_clear': 'GsiHofXClr',     #emily
+    'Inverse_Observation_Error': 'GsiFinalObsError',
+    'Bias_Correction': 'GsiBc',
+    'Bias_Correction_Constant': 'GsiBcConst',      #emily
+    'Bias_Correction_ScanAngle': 'GsiBcScanAng',   #emily
+    'hxdbz': 'GsiHofX',
+    'hxrw': 'GsiHofX',
+}
+#<<emily
 
 gsi_add_vars = {
     'Observation_Type': 'ObsType',
@@ -220,6 +248,7 @@ geovals_vars = {
     'tropopause_pressure': 'tropopause_pressure',
     'surface_pressure': 'surface_pressure',
     'surface_temperature': 'surface_temperature',
+    'sea_surface_temperature': 'sea_surface_temperature',   #emily
     'surface_roughness': 'surface_roughness_length',
     'surface_height': 'surface_geopotential_height',
     'landmask': 'land_area_fraction',
@@ -292,6 +321,9 @@ aod_sensors = [
 oz_sensors = [
     'gome',
     'sbuv2',
+    'omi',       #emily
+    'ompsnp',    #emily
+    'ompstc8',   #emily
 ]
 
 # units
@@ -305,6 +337,7 @@ units_values = {
     'geopotential_height': 'm',
     'height_above_mean_sea_level': 'm',
     'surface_pressure': 'Pa',
+    'sea_surface_temperature': 'K',    #emily
     'surface_temperature': 'K',
     'surface_roughness_length': 'm',
     'surface_geopotential_height': 'm',
@@ -378,23 +411,18 @@ units_values = {
 # @TestReference
 # fields from GSI to compare to computations done in UFO
 test_fields = {
-    'clw_obs': ('cloud_liquid_water_column_retrieved_from_observations', 'float'),
-    'clw_guess_retrieval': ('cloud_liquid_water_content_retrieved_from_calculated_radiances', 'float'),
-    'Cloud_Frac': ('retrieved_cloud_fraction', 'float'),
-    'CTP': ('retrieved_cloud_top_pressure', 'float'),
-    'CLW': ('cloud_liquid_water_used_in_QC', 'float'),
-    'TPWC': ('total_preciptable_water_content_retrieval', 'float'),
-    'clw_guess': ('cloud_liquid_water_column_retrieved_from_calculated_radiances', 'float'),
-    'Weighted_Lapse_Rate': ('lapse_rate_convolved_with_weighting_function', 'float'),
-    'BC_Constant': ('constant_bias_correction_term', 'float'),
-    'BC_Cloud_Liquid_Water': ('cloud_liquid_water_bias_correction_term', 'float'),
-    'BC_Lapse_Rate_Squared': ('lapse_rate_squared_bias_correction_term', 'float'),
-    'BC_Lapse_Rate': ('lapse_rate_bias_correction_term', 'float'),
-    'BC_Cosine_Latitude_times_Node': ('cosine_of_latitude_times_orbit_node_bias_correction_term', 'float'),
-    'BC_Sine_Latitude': ('sine_of_latitude_bias_correction_term', 'float'),
-    'BC_Emissivity': ('emissivity_bias_correction_term', 'float'),
-    'BC_Fixed_Scan_Position': ('scan_angle_bias_correction_term', 'float'),
 }
+#>>emily
+test_fields_allsky = {
+    'clwp_amsua': ('clw_retrieved_from_observation', 'float'),
+    'clw_guess_retrieval': ('clw_retrieved_from_background', 'float'),
+}
+test_fields_with_channels = {
+#    'Forecast_adjusted': ('GsiHofXBc', 'float'),
+#    'Forecast_unadjusted': ('GsiHofX', 'float'),
+#    'Bias_Correction': ('GsiBc', 'float'),
+}
+#<<emily
 
 ###############################################################################
 ###############################################################################
@@ -468,6 +496,12 @@ class Conv:
             for p in platforms:
                 outname = OutDir + '/' + p + '_' + v + '_geoval_' + \
                     self.validtime.strftime("%Y%m%d%H") + '.nc4'
+#>>emily
+                if (v == 'sst'):
+                    outname = OutDir + '/' + v + '_geoval_' + \
+                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                print("emily checking outname = ", outname)
+#<<emily
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting:")
@@ -496,6 +530,11 @@ class Conv:
                 nlocs = np.sum(idx)
                 ncout.createDimension("nlocs", nlocs)
                 # other dims
+#>>emily        
+                if (v != "sst" ):
+                  ncout.createDimension(
+                      "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
+#<<emily 
                 ncout.createDimension(
                     "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
                 dimname = "Station_ID_maxstrlen"
@@ -548,6 +587,11 @@ class Conv:
                 # set up a NcWriter class
                 outname = OutDir + '/' + p + '_' + v + '_obs_' + \
                     self.validtime.strftime("%Y%m%d%H") + '.nc4'
+#>>emily
+                if (v == 'sst'):
+                    outname = OutDir + '/' + v + '_obs_' + \
+                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
+#<<emily
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting:")
@@ -944,6 +988,14 @@ class Radiances:
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         test_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
+#>>emily
+        if self.sensor == "amsua":
+            test_fields = test_fields_allsky
+        elif self.sensor == "atms":
+            test_fields = test_fields_allsky
+        else:
+             test_fields = test_fields_
+#<<emily
         # get list of location variable for this var/platform
         for ncv in self.df.variables:
             if ncv in all_LocKeyList:
@@ -955,7 +1007,11 @@ class Radiances:
             if ncv in test_fields:
                 TestKeyList.append(test_fields[ncv])
                 TestVars.append(ncv)
-
+#>>emily
+            if ncv in test_fields_with_channels:
+                TestKeyList.append(test_fields_with_channels[ncv])
+                TestVars.append(ncv)
+#<<emily
         # for now, record len is 1 and the list is empty?
         recKey = 0
         writer = iconv.NcWriter(outname, RecKeyList, LocKeyList, TestKeyList=TestKeyList)
@@ -974,14 +1030,15 @@ class Radiances:
             units_values[value] = 'K'
 
         obsdata = self.df['Observation'][:]
-        obserr = self.df['error_variance'][:]
+#       obserr = self.df['error_variance'][:]   #orig
+        obserr = self.df['Input_ObsError'][:]   #emily
         obsqc = self.df['QC_Flag'][:].astype(int)
 
         for lvar in LocVars:
             loc_mdata_name = all_LocKeyList[lvar][0]
             if lvar == 'Obs_Time':
                 tmp = self.df[lvar][::nchans]
-                obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
+			obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
             else:
@@ -990,14 +1047,48 @@ class Radiances:
                 loc_mdata[loc_mdata_name] = tmp
 
         # put the TestReference fields in the structure for writing out
+#>>orig
+#        for tvar in TestVars:
+#            test_mdata_name = test_fields[tvar][0]
+#            tmp = self.df[tvar][::nchans]
+#            tmp[tmp > 4e8] = nc.default_fillvals['f4']
+#            test_mdata[test_mdata_name] = tmp
+#<<orig
+#>>emily
         for tvar in TestVars:
-            test_mdata_name = test_fields[tvar][0]
-            tmp = self.df[tvar][::nchans]
-            tmp[tmp > 4e8] = nc.default_fillvals['f4']
-            test_mdata[test_mdata_name] = tmp
+            if tvar in test_fields_with_channels:
+                for ii, ch in enumerate(chanlist):
+                   test_mdata_name = test_fields_with_channels[tvar][0]+"_{:d}".format(ch)
+                #  tmp = self.df[tvar][::nchans]
+                   tmp = self.df[tvar][:]
+                   tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                   idx = chan_indx == ii+1
+                   outvals = tmp[idx]
+                   test_mdata[test_mdata_name] = outvals
+               #    print("emily checking tvar:",tvar)
+               #    print("emily checking test_mdata_name:",test_mdata_name)
+               #    print("emily checking outvals:",outvals)
+               #    print("emily checking test_mdata:",test_mdata[test_mdata_name])
+            if tvar in test_fields:
+                test_mdata_name = test_fields[tvar][0]
+                tmp = self.df[tvar][::nchans]
+                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                test_mdata[test_mdata_name] = tmp
+             #   print("emily checking tvar:",tvar)
+             #   print("emily checking test_mdata_name:",test_mdata_name)
+             #   print("emily checking tmp:",tmp)
+             #   print("emily checking test_mdata:",test_mdata[test_mdata_name])
 
+        gsi_add_radvars = gsi_add_vars
+        if self.sensor == "amsua":
+            gsi_add_radvars = gsi_add_vars_allsky
+
+        if self.sensor == "atms":
+            gsi_add_radvars = gsi_add_vars_allsky
+#<<emily
         # check for additional GSI output for each variable
-        for gsivar, iodavar in gsi_add_vars.items():
+#       for gsivar, iodavar in gsi_add_vars.items():     #orig
+        for gsivar, iodavar in gsi_add_radvars.items():  #emily
             if gsivar in self.df.variables:
                 if "Inverse" in gsivar:
                     tmp2 = self.df[gsivar][:]
@@ -1030,7 +1121,8 @@ class Radiances:
                 continue
             obsdatasub = obsdata[idx]
             obsdatasub[obsdatasub > 9e5] = nc.default_fillvals['f4']
-            obserrsub = np.full(nlocs, obserr[c])
+#           obserrsub = np.full(nlocs, obserr[c])    #orig
+            obserrsub = obserr[idx]                  #emily
             obsqcsub = obsqc[idx]
             obsqcsub[obsdatasub > 9e5] = nc.default_fillvals['i4']
 
@@ -1439,9 +1531,11 @@ class Ozone:
         varDict[vname]['qcKey'] = vname, writer.OqcName()
 
         obsdata = self.df['Observation'][:]
-        tmp = self.df['Inverse_Observation_Error'][:]
+#       tmp = self.df['Inverse_Observation_Error'][:]   #orig
+        tmp = self.df['Input_Observation_Error'][:]     #emily
         tmp[tmp < 9e-12] = 0
-        obserr = 1.0 / tmp
+#       obserr = 1.0 / tmp   #orig
+        obserr = tmp         #emily
         obserr[np.isinf(obserr)] = nc.default_fillvals['f4']
         obsqc = self.df['Analysis_Use_Flag'][:].astype(int)
         locKeys = []

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -36,7 +36,7 @@ conv_platforms = {
     ],
     "conv_gps": [
         'gps',
-    ]
+    ],
 #>>emily
     "conv_sst": [
         'sst',
@@ -535,8 +535,10 @@ class Conv:
                   ncout.createDimension(
                       "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
 #<<emily 
-                ncout.createDimension(
-                    "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
+#>>orig
+#                ncout.createDimension(
+#                    "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
+#<<orig
                 dimname = "Station_ID_maxstrlen"
                 ncout.createDimension(dimname, self.df.dimensions[dimname].size)
                 dimname = "Observation_Class_maxstrlen"
@@ -1038,7 +1040,7 @@ class Radiances:
             loc_mdata_name = all_LocKeyList[lvar][0]
             if lvar == 'Obs_Time':
                 tmp = self.df[lvar][::nchans]
-			obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
+                obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
             else:

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -37,11 +37,9 @@ conv_platforms = {
     "conv_gps": [
         'gps',
     ],
-#>>emily
     "conv_sst": [
         'sst',
     ]
-#<<emily
 }
 
 # note in python range, last number is not used so second values are +1
@@ -63,8 +61,8 @@ conv_bufrtypes = {
     "rass": [126],
     "sfcship": [180, 183],
     "sfc": [181, 187],
-    "gps": [3, 4, 42, 43, 745, 825],  #emily
-    "sst": [181, 182, 183, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202], #emily sst
+    "gps": [3, 4, 42, 43, 745, 825],
+    "sst": [181, 182, 183, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202],
 }
 
 # LocKeyList = { 'gsiname':('IODAname','dtype')}
@@ -110,7 +108,7 @@ conv_varnames = {
     "q": ["specific_humidity"],
     "bend": ["bending_angle"],
     "refract": ["refractivity"],
-    "sst": ["sea_surface_temperature"],  #emily sst
+    "sst": ["sea_surface_temperature"],
 }
 
 conv_gsivarnames = {
@@ -121,10 +119,9 @@ conv_gsivarnames = {
     "q": ["Observation"],
     "bend": ["Observation"],
     "refract": ["Observation"],
-    "sst": ["Observation"],      #emily sst
+    "sst": ["Observation"],
 }
 
-#>>emily
 gsi_add_vars_allsky = {
     'Observation_Type': 'ObsType',
     'Prep_Use_Flag': 'PreUseFlag',
@@ -134,15 +131,14 @@ gsi_add_vars_allsky = {
     'Errinv_Final': 'GsiFinalObsError',
     'Forecast_adjusted': 'GsiHofXBc',
     'Forecast_unadjusted': 'GsiHofX',
-    'Forecast_unadjusted_clear': 'GsiHofXClr',     #emily
+    'Forecast_unadjusted_clear': 'GsiHofXClr',
     'Inverse_Observation_Error': 'GsiFinalObsError',
     'Bias_Correction': 'GsiBc',
-    'Bias_Correction_Constant': 'GsiBcConst',      #emily
-    'Bias_Correction_ScanAngle': 'GsiBcScanAng',   #emily
+    'Bias_Correction_Constant': 'GsiBcConst',
+    'Bias_Correction_ScanAngle': 'GsiBcScanAng',
     'hxdbz': 'GsiHofX',
     'hxrw': 'GsiHofX',
 }
-#<<emily
 
 gsi_add_vars = {
     'Observation_Type': 'ObsType',
@@ -248,7 +244,7 @@ geovals_vars = {
     'tropopause_pressure': 'tropopause_pressure',
     'surface_pressure': 'surface_pressure',
     'surface_temperature': 'surface_temperature',
-    'sea_surface_temperature': 'sea_surface_temperature',   #emily
+    'sea_surface_temperature': 'sea_surface_temperature',
     'surface_roughness': 'surface_roughness_length',
     'surface_height': 'surface_geopotential_height',
     'landmask': 'land_area_fraction',
@@ -321,9 +317,9 @@ aod_sensors = [
 oz_sensors = [
     'gome',
     'sbuv2',
-    'omi',       #emily
-    'ompsnp',    #emily
-    'ompstc8',   #emily
+    'omi',
+    'ompsnp',
+    'ompstc8',
 ]
 
 # units
@@ -337,7 +333,7 @@ units_values = {
     'geopotential_height': 'm',
     'height_above_mean_sea_level': 'm',
     'surface_pressure': 'Pa',
-    'sea_surface_temperature': 'K',    #emily
+    'sea_surface_temperature': 'K',
     'surface_temperature': 'K',
     'surface_roughness_length': 'm',
     'surface_geopotential_height': 'm',
@@ -412,17 +408,12 @@ units_values = {
 # fields from GSI to compare to computations done in UFO
 test_fields = {
 }
-#>>emily
 test_fields_allsky = {
     'clwp_amsua': ('clw_retrieved_from_observation', 'float'),
     'clw_guess_retrieval': ('clw_retrieved_from_background', 'float'),
 }
 test_fields_with_channels = {
-#    'Forecast_adjusted': ('GsiHofXBc', 'float'),
-#    'Forecast_unadjusted': ('GsiHofX', 'float'),
-#    'Bias_Correction': ('GsiBc', 'float'),
 }
-#<<emily
 
 ###############################################################################
 ###############################################################################
@@ -496,12 +487,9 @@ class Conv:
             for p in platforms:
                 outname = OutDir + '/' + p + '_' + v + '_geoval_' + \
                     self.validtime.strftime("%Y%m%d%H") + '.nc4'
-#>>emily
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + '_geoval_' + \
-                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
-                print("emily checking outname = ", outname)
-#<<emily
+                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting:")
@@ -530,15 +518,9 @@ class Conv:
                 nlocs = np.sum(idx)
                 ncout.createDimension("nlocs", nlocs)
                 # other dims
-#>>emily        
-                if (v != "sst" ):
-                  ncout.createDimension(
-                      "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
-#<<emily 
-#>>orig
-#                ncout.createDimension(
-#                    "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
-#<<orig
+                if (v != "sst"):
+                    ncout.createDimension(
+                        "nlevs", self.df.dimensions["atmosphere_pressure_coordinate_arr_dim"].size)
                 dimname = "Station_ID_maxstrlen"
                 ncout.createDimension(dimname, self.df.dimensions[dimname].size)
                 dimname = "Observation_Class_maxstrlen"
@@ -589,11 +571,9 @@ class Conv:
                 # set up a NcWriter class
                 outname = OutDir + '/' + p + '_' + v + '_obs_' + \
                     self.validtime.strftime("%Y%m%d%H") + '.nc4'
-#>>emily
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + '_obs_' + \
-                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
-#<<emily
+                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting:")
@@ -990,14 +970,12 @@ class Radiances:
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         test_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-#>>emily
         if self.sensor == "amsua":
             test_fields = test_fields_allsky
         elif self.sensor == "atms":
             test_fields = test_fields_allsky
         else:
-             test_fields = test_fields_
-#<<emily
+            test_fields = test_fields_
         # get list of location variable for this var/platform
         for ncv in self.df.variables:
             if ncv in all_LocKeyList:
@@ -1009,11 +987,9 @@ class Radiances:
             if ncv in test_fields:
                 TestKeyList.append(test_fields[ncv])
                 TestVars.append(ncv)
-#>>emily
             if ncv in test_fields_with_channels:
                 TestKeyList.append(test_fields_with_channels[ncv])
                 TestVars.append(ncv)
-#<<emily
         # for now, record len is 1 and the list is empty?
         recKey = 0
         writer = iconv.NcWriter(outname, RecKeyList, LocKeyList, TestKeyList=TestKeyList)
@@ -1032,8 +1008,8 @@ class Radiances:
             units_values[value] = 'K'
 
         obsdata = self.df['Observation'][:]
-#       obserr = self.df['error_variance'][:]   #orig
-        obserr = self.df['Input_ObsError'][:]   #emily
+#       obserr = self.df['error_variance'][:]
+        obserr = self.df['Input_Observation_Error'][:]
         obsqc = self.df['QC_Flag'][:].astype(int)
 
         for lvar in LocVars:
@@ -1049,37 +1025,21 @@ class Radiances:
                 loc_mdata[loc_mdata_name] = tmp
 
         # put the TestReference fields in the structure for writing out
-#>>orig
-#        for tvar in TestVars:
-#            test_mdata_name = test_fields[tvar][0]
-#            tmp = self.df[tvar][::nchans]
-#            tmp[tmp > 4e8] = nc.default_fillvals['f4']
-#            test_mdata[test_mdata_name] = tmp
-#<<orig
-#>>emily
         for tvar in TestVars:
             if tvar in test_fields_with_channels:
                 for ii, ch in enumerate(chanlist):
-                   test_mdata_name = test_fields_with_channels[tvar][0]+"_{:d}".format(ch)
-                #  tmp = self.df[tvar][::nchans]
-                   tmp = self.df[tvar][:]
-                   tmp[tmp > 4e8] = nc.default_fillvals['f4']
-                   idx = chan_indx == ii+1
-                   outvals = tmp[idx]
-                   test_mdata[test_mdata_name] = outvals
-               #    print("emily checking tvar:",tvar)
-               #    print("emily checking test_mdata_name:",test_mdata_name)
-               #    print("emily checking outvals:",outvals)
-               #    print("emily checking test_mdata:",test_mdata[test_mdata_name])
+                    test_mdata_name = test_fields_with_channels[tvar][0]+"_{:d}".format(ch)
+                #   tmp = self.df[tvar][::nchans]
+                    tmp = self.df[tvar][:]
+                    tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                    idx = chan_indx == ii+1
+                    outvals = tmp[idx]
+                    test_mdata[test_mdata_name] = outvals
             if tvar in test_fields:
                 test_mdata_name = test_fields[tvar][0]
                 tmp = self.df[tvar][::nchans]
                 tmp[tmp > 4e8] = nc.default_fillvals['f4']
                 test_mdata[test_mdata_name] = tmp
-             #   print("emily checking tvar:",tvar)
-             #   print("emily checking test_mdata_name:",test_mdata_name)
-             #   print("emily checking tmp:",tmp)
-             #   print("emily checking test_mdata:",test_mdata[test_mdata_name])
 
         gsi_add_radvars = gsi_add_vars
         if self.sensor == "amsua":
@@ -1087,10 +1047,8 @@ class Radiances:
 
         if self.sensor == "atms":
             gsi_add_radvars = gsi_add_vars_allsky
-#<<emily
         # check for additional GSI output for each variable
-#       for gsivar, iodavar in gsi_add_vars.items():     #orig
-        for gsivar, iodavar in gsi_add_radvars.items():  #emily
+        for gsivar, iodavar in gsi_add_radvars.items():
             if gsivar in self.df.variables:
                 if "Inverse" in gsivar:
                     tmp2 = self.df[gsivar][:]
@@ -1123,8 +1081,8 @@ class Radiances:
                 continue
             obsdatasub = obsdata[idx]
             obsdatasub[obsdatasub > 9e5] = nc.default_fillvals['f4']
-#           obserrsub = np.full(nlocs, obserr[c])    #orig
-            obserrsub = obserr[idx]                  #emily
+#           obserrsub = np.full(nlocs, obserr[c])
+            obserrsub = obserr[idx]
             obsqcsub = obsqc[idx]
             obsqcsub[obsdatasub > 9e5] = nc.default_fillvals['i4']
 
@@ -1533,11 +1491,11 @@ class Ozone:
         varDict[vname]['qcKey'] = vname, writer.OqcName()
 
         obsdata = self.df['Observation'][:]
-#       tmp = self.df['Inverse_Observation_Error'][:]   #orig
-        tmp = self.df['Input_Observation_Error'][:]     #emily
+#       tmp = self.df['Inverse_Observation_Error'][:]
+        tmp = self.df['Input_Observation_Error'][:]
         tmp[tmp < 9e-12] = 0
-#       obserr = 1.0 / tmp   #orig
-        obserr = tmp         #emily
+#       obserr = 1.0 / tmp
+        obserr = tmp
         obserr[np.isinf(obserr)] = nc.default_fillvals['f4']
         obsqc = self.df['Analysis_Use_Flag'][:].astype(int)
         locKeys = []

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -1008,7 +1008,6 @@ class Radiances:
             units_values[value] = 'K'
 
         obsdata = self.df['Observation'][:]
-#       obserr = self.df['error_variance'][:]
         obserr = self.df['Input_Observation_Error'][:]
         obsqc = self.df['QC_Flag'][:].astype(int)
 
@@ -1081,7 +1080,6 @@ class Radiances:
                 continue
             obsdatasub = obsdata[idx]
             obsdatasub[obsdatasub > 9e5] = nc.default_fillvals['f4']
-#           obserrsub = np.full(nlocs, obserr[c])
             obserrsub = obserr[idx]
             obsqcsub = obsqc[idx]
             obsqcsub[obsdatasub > 9e5] = nc.default_fillvals['i4']
@@ -1491,10 +1489,8 @@ class Ozone:
         varDict[vname]['qcKey'] = vname, writer.OqcName()
 
         obsdata = self.df['Observation'][:]
-#       tmp = self.df['Inverse_Observation_Error'][:]
         tmp = self.df['Input_Observation_Error'][:]
         tmp[tmp < 9e-12] = 0
-#       obserr = 1.0 / tmp
         obserr = tmp
         obserr[np.isinf(obserr)] = nc.default_fillvals['f4']
         obsqc = self.df['Analysis_Use_Flag'][:].astype(int)

--- a/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
+++ b/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85b8d8f89cef53d3f6dac909dafa8e6ccadaeddc1109524610798d1c0c5e69a3
-size 8942750
+oid sha256:088f5157fa1923445393f6d2e09df6b55130a9e9afbb1617f31db02c9d0063f8
+size 505127

--- a/test/testoutput/amsua_aqua_obs_2018041500.nc4
+++ b/test/testoutput/amsua_aqua_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d507c016e4cb941c6d69d8eae5b9659ce3524f7b5817547950981d56faf63f80
-size 125233
+oid sha256:13e9e69e5acc9e1324c470d521321d71c68e9e8721ca7d950587d626d6acc48e
+size 167912


### PR DESCRIPTION
**Enhancements made in this PR:**
(1) Added handling of sea surface temperature data
(2) Include OMP sensors for ozone data type
(3) Updated list of observation types (bufr types) for GPS and SST
(4) Added missing units for some variables
(5) Enhanced the capability of adding test fields to handle data with channel dimension

**Issues and related bug fix:**
The initial observation error values stored in @ObsError group were not correct for all-sky radiance and ozone data.

**Issues:**
- (1) The clear-sky observation error values were used for the all-sky case. While the clear-sky errors are assigned to constant for each channel globally, the all-sky errors for each channel vary at each observation location.  
- (2) The final observation error values (adjusted values) were stored in @ObsError group.  

**Bug fix:**
- Stored correct initial observation error assignment in @ObsError group for all-sky radiance and ozone data.