### PR TITLE
Removed the use of nrecs in IODA obs files

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -579,13 +579,11 @@ class Conv:
                         print("File exists. Skipping and not overwriting:")
                         print(outname)
                         continue
-                RecKeyList = []
                 LocKeyList = []
                 LocVars = []
                 AttrData = {}
                 varDict = defaultdict(lambda: defaultdict(dict))
                 outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-                rec_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
                 loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
                 var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
                 # get list of location variable for this var/platform
@@ -593,9 +591,6 @@ class Conv:
                     if ncv in all_LocKeyList:
                         LocKeyList.append(all_LocKeyList[ncv])
                         LocVars.append(ncv)
-                # use station_id for RecKey
-                RecKeyList.append('Station_ID')
-
                 # grab obs to process
                 idx = grabobsidx(self.df, p, v)
                 if (np.sum(idx) == 0):
@@ -605,7 +600,7 @@ class Conv:
                 print("Platform:" + p + " Var:" + v)
                 print(str(np.sum(idx))+" obs to process")
 
-                writer = iconv.NcWriter(outname, RecKeyList, LocKeyList)
+                writer = iconv.NcWriter(outname, LocKeyList)
 
                 outvars = conv_varnames[v]
                 for value in outvars:
@@ -685,7 +680,6 @@ class Conv:
 
                 # record info
                 SIDUnique, idxs, invs = np.unique(StationIDs, return_index=True, return_inverse=True, axis=0)
-                rec_mdata['Station_ID'] = writer.FillNcVector(SIDUnique, "string")
                 loc_mdata['record_number'] = invs
 
                 # var metadata
@@ -696,12 +690,10 @@ class Conv:
                 # writer metadata
                 nvars = len(outvars)
                 nlocs = len(StationIDs)
-                nrecs = len(SIDUnique)
 
-                writer._nrecs = nrecs
                 writer._nvars = nvars
                 writer._nlocs = nlocs
-                writer.BuildNetcdf(outdata, rec_mdata, loc_mdata, var_mdata, AttrData, units_values)
+                writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
                 print(str(len(obsdata))+" Conventional obs processed, wrote to:")
                 print(outname)
 
@@ -958,7 +950,6 @@ class Radiances:
                 print("File exists. Skipping and not overwriting:")
                 print(outname)
                 return
-        RecKeyList = []
         LocKeyList = []
         TestKeyList = []
         LocVars = []
@@ -966,7 +957,6 @@ class Radiances:
         AttrData = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-        rec_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         test_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
@@ -991,8 +981,7 @@ class Radiances:
                 TestKeyList.append(test_fields_with_channels[ncv])
                 TestVars.append(ncv)
         # for now, record len is 1 and the list is empty?
-        recKey = 0
-        writer = iconv.NcWriter(outname, RecKeyList, LocKeyList, TestKeyList=TestKeyList)
+        writer = iconv.NcWriter(outname, LocKeyList, TestKeyList=TestKeyList)
 
         chan_number = self.df['sensor_chan'][:]
         chan_number = chan_number[chan_number >= 0]
@@ -1098,8 +1087,6 @@ class Radiances:
                 pass
 
         # dummy record metadata, for now
-        nrecs = 1
-        rec_mdata['rec_id'] = np.asarray([999], dtype='i4')
         loc_mdata['record_number'] = np.full((nlocs), 1, dtype='i4')
 
         # global attributes
@@ -1110,11 +1097,10 @@ class Radiances:
 
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        writer._nrecs = nrecs
         writer._nvars = nchans
         writer._nlocs = nlocs
 
-        writer.BuildNetcdf(outdata, rec_mdata, loc_mdata, var_mdata,
+        writer.BuildNetcdf(outdata, loc_mdata, var_mdata,
                            AttrData, units_values, test_mdata)
         print("Satellite radiance obs processed, wrote to:")
         print(outname)
@@ -1234,13 +1220,11 @@ class AOD:
                 print("File exists. Skipping and not overwriting:")
                 print(outname)
                 return
-        RecKeyList = []
         LocKeyList = []
         LocVars = []
         AttrData = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-        rec_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         # get list of location variable for this var/platform
@@ -1250,8 +1234,7 @@ class AOD:
                 LocVars.append(ncv)
 
         # for now, record len is 1 and the list is empty?
-        recKey = 0
-        writer = iconv.NcWriter(outname, RecKeyList, LocKeyList)
+        writer = iconv.NcWriter(outname, LocKeyList)
 
         chan_number = self.df['sensor_chan'][:]
         chan_number = chan_number[chan_number >= 0]
@@ -1331,8 +1314,6 @@ class AOD:
                 pass
 
         # dummy record metadata, for now
-        nrecs = 1
-        rec_mdata['rec_id'] = np.asarray([999], dtype='i4')
         loc_mdata['record_number'] = np.full((nlocs), 1, dtype='i4')
 
         # global attributes
@@ -1341,11 +1322,10 @@ class AOD:
         AttrData["sensor"] = self.sensor
 
         # set dimension lengths in the writer since we are bypassing ExtractObsData
-        writer._nrecs = nrecs
         writer._nvars = nchans
         writer._nlocs = nlocs
 
-        writer.BuildNetcdf(outdata, rec_mdata, loc_mdata, var_mdata, AttrData, units_values)
+        writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
         print("AOD obs processed, wrote to:")
         print(outname)
 
@@ -1464,13 +1444,11 @@ class Ozone:
                 print("File exists. Skipping and not overwriting:")
                 print(outname)
                 return
-        RecKeyList = []
         LocKeyList = []
         LocVars = []
         AttrData = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-        rec_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         # get list of location variable for this var/platform
@@ -1479,8 +1457,7 @@ class Ozone:
                 LocKeyList.append(all_LocKeyList[ncv])
                 LocVars.append(ncv)
         # for now, record len is 1 and the list is empty?
-        recKey = 0
-        writer = iconv.NcWriter(outname, RecKeyList, LocKeyList)
+        writer = iconv.NcWriter(outname, LocKeyList)
 
         nlocs = self.nobs
         vname = "mole_fraction_of_ozone_in_air"
@@ -1530,8 +1507,6 @@ class Ozone:
         outdata[varDict[vname]['qcKey']] = obsqc
 
         # dummy record metadata, for now
-        nrecs = 1
-        rec_mdata['rec_id'] = np.asarray([999], dtype='i4')
         loc_mdata['record_number'] = np.full((nlocs), 1, dtype='i4')
 
         AttrData["date_time_string"] = self.validtime.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -1539,11 +1514,10 @@ class Ozone:
         AttrData["sensor"] = self.sensor
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        writer._nrecs = nrecs
         writer._nvars = 1
         writer._nlocs = nlocs
 
-        writer.BuildNetcdf(outdata, rec_mdata, loc_mdata, var_mdata, AttrData, units_values)
+        writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
         print("Ozone obs processed, wrote to:")
         print(outname)
 
@@ -1660,13 +1634,11 @@ class Radar:
                 print("File exists. Skipping and not overwriting:")
                 print(outname)
                 return
-        RecKeyList = []
         LocKeyList = []
         LocVars = []
         AttrData = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
-        rec_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         loc_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         # get list of location variable for this var/platform
@@ -1675,8 +1647,7 @@ class Radar:
                 LocKeyList.append(all_LocKeyList[ncv])
                 LocVars.append(ncv)
         # for now, record len is 1 and the list is empty?
-        recKey = 0
-        writer = iconv.NcWriter(outname, RecKeyList, LocKeyList)
+        writer = iconv.NcWriter(outname, LocKeyList)
 
         nlocs = self.nobs
         if self.obstype == "dbz":
@@ -1738,18 +1709,15 @@ class Radar:
                 loc_mdata[loc_mdata_name] = tmp
 
         # dummy record metadata, for now
-        nrecs = 1
-        rec_mdata['rec_id'] = np.asarray([999], dtype='i4')
         loc_mdata['record_number'] = np.full((nlocs), 1, dtype='i4')
 
         AttrData["date_time_string"] = self.validtime.strftime("%Y-%m-%dT%H:%M:%SZ")
         AttrData["sensor"] = self.sensor
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        writer._nrecs = nrecs
         writer._nvars = 1
         writer._nlocs = nlocs
 
-        writer.BuildNetcdf(outdata, rec_mdata, loc_mdata, var_mdata, AttrData, units_values)
+        writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
         print("Radar obs processed, wrote to:")
         print(outname)

--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -47,10 +47,9 @@ def CharVectorToString(CharVec):
 
 class NcWriter(object):
     # Constructor
-    def __init__(self, NcFname, RecKeyList, LocKeyList, TestKeyList=None):
+    def __init__(self, NcFname, LocKeyList, TestKeyList=None):
 
         # Variable names of items in the record key
-        self._rec_key_list = RecKeyList
 
         # Variable names of items in the location key
         self._loc_key_list = LocKeyList
@@ -64,7 +63,6 @@ class NcWriter(object):
         self._oqc_name = "PreQC"
 
         # Names assigned to dimensions
-        self._nrecs_dim_name = 'nrecs'
         self._nlocs_dim_name = 'nlocs'
         self._nvars_dim_name = 'nvars'
         self._nstr_dim_name = 'nstring'
@@ -73,7 +71,6 @@ class NcWriter(object):
         # Dimension sizes
         self._nlocs = 0
         self._nvars = 0
-        self._nrecs = 0
         self._nstring = 50
         self._ndatetime = 20
 
@@ -88,7 +85,6 @@ class NcWriter(object):
         self._var_list_name = "variable_names"
 
         # Names for metadata groups
-        self._rec_md_name = "RecMetaData"
         self._loc_md_name = "MetaData"
         self._var_md_name = "VarMetaData"
         self._test_md_name = "TestReference"
@@ -230,7 +226,6 @@ class NcWriter(object):
         # This method will dump out the netcdf global attribute data
         # contained in the dictionary AttrData.
 
-        self._fid.setncattr(self._nrecs_dim_name, np.int32(self._nrecs))
         self._fid.setncattr(self._nvars_dim_name, np.int32(self._nvars))
         self._fid.setncattr(self._nlocs_dim_name, np.int32(self._nlocs))
 
@@ -257,7 +252,6 @@ class NcWriter(object):
         # rearrange the group structure.
         self._fid.createDimension(self._nvars_dim_name, self._nvars)
         self._fid.createDimension(self._nlocs_dim_name, self._nlocs)
-        self._fid.createDimension(self._nrecs_dim_name, self._nrecs)
         self._fid.createDimension(self._nstr_dim_name, self._nstring)
         self._fid.createDimension(self._ndatetime_dim_name, self._ndatetime)
 
@@ -268,7 +262,9 @@ class NcWriter(object):
             self._fid.createVariable(NcVname, self.NumpyToNcDtype(Vvals.dtype), (self._nlocs_dim_name))
             self._fid[NcVname][:] = Vvals
             # add units
-            if Gname in ['ObsValue', 'ObsError', 'GsiHofX', 'GsiHofXBc']:
+            if Gname in ['ObsValue', 'ObsError', 'GsiHofX', 'GsiHofXBc',
+                         'GsiHofXClr', 'GsiFinalObsError', 'GsiBc', 'GsiBcConst',
+                         'GsiBcScanAng', 'GsiAdjustObsError', 'GsiFinalObsError']:
                 try:
                     self._fid[NcVname].setncattr_string("units", VarUnits[Vname])
                 except KeyError:
@@ -316,7 +312,6 @@ class NcWriter(object):
         # dictionary and reformat it into a more amenable form for
         # writing into the output file.
 
-        self._nrecs = 0
         self._nvars = 0
         self._nlocs = 0
 
@@ -328,8 +323,9 @@ class NcWriter(object):
         ObsVarExamples = []
         VMName = []
         VMData = {}
+        nrecs = 0
         for RecKey, RecDict in ObsData.items():
-            self._nrecs += 1
+            nrecs += 1
             for LocKey, LocDict in RecDict.items():
                 self._nlocs += 1
                 for VarKey, VarVal in LocDict.items():
@@ -338,7 +334,6 @@ class NcWriter(object):
                     if (VarKey not in ObsVarList):
                         ObsVarList.append(VarKey)
                         ObsVarExamples.append(VarVal)
-
         VarList = sorted(list(VarNames))
         self._nvars = len(VarList)
 
@@ -374,12 +369,6 @@ class NcWriter(object):
 
         VarMdata = OrderedDict()
         VarMdata[self._var_list_name] = self.CreateNcVector(self._nvars, "string")
-
-        RecMdata = OrderedDict()
-        for i in range(len(self._rec_key_list)):
-            (RecVname, RecVtype) = self._rec_key_list[i]
-            RecMdata[RecVname] = self.CreateNcVector(self._nrecs, RecVtype)
-
         VarMdata[self._var_list_name] = self.FillNcVector(VarList, "string")
 
         RecNum = 0
@@ -388,10 +377,6 @@ class NcWriter(object):
             RecNum += 1
 
             # Exract record metadata encoded in the keys
-            for i in range(len(self._rec_key_list)):
-                (RecVname, RecVtype) = self._rec_key_list[i]
-                RecMdata[RecVname][RecNum-1] = self.FillNcVector(RecKey[i], RecVtype)
-
             for LocKey, LocDict in RecDict.items():
                 LocNum += 1
 
@@ -412,9 +397,9 @@ class NcWriter(object):
                         VarVal = self._defaultF4
                     ObsVars[VarKey][LocNum-1] = VarVal
 
-        return (ObsVars, RecMdata, LocMdata, VarMdata)
+        return (ObsVars, LocMdata, VarMdata)
 
-    def BuildNetcdf(self, ObsVars, RecMdata, LocMdata, VarMdata, AttrData, VarUnits={}, TestData=None):
+    def BuildNetcdf(self, ObsVars, LocMdata, VarMdata, AttrData, VarUnits={}, TestData=None):
         ############################################################
         # This method will create an output netcdf file, and dump
         # the contents of the ObsData dictionary into that file.
@@ -422,7 +407,6 @@ class NcWriter(object):
         # The structure of the output file is:
         #
         #  global attributes:
-        #     nrecs
         #     nvars
         #     nlocs
         #     contents of AttrData dictionary
@@ -447,10 +431,6 @@ class NcWriter(object):
         #         latitude
         #         longitude
         #         datetime
-        #     /RecMetaData/
-        #         Group holding 1D vectors of various data types, nrecs
-        #         station_id
-        #         analysis_date_time
         #     /VarUnits/
         #         Dictionary holding string of units for each variable/metadata item
         #         Key: variable, Value: unit_string
@@ -465,7 +445,6 @@ class NcWriter(object):
         self.WriteNcAttr(AttrData)
         self.WriteNcObsVars(ObsVars, VarMdata, VarUnits)
 
-        self.WriteNcMetadata(self._rec_md_name, self._nrecs_dim_name, RecMdata, VarUnits)
         self.WriteNcMetadata(self._loc_md_name, self._nlocs_dim_name, LocMdata, VarUnits)
         self.WriteNcMetadata(self._var_md_name, self._nvars_dim_name, VarMdata, VarUnits)
         if TestData is not None:

--- a/src/marine/argoClim2ioda.py.in
+++ b/src/marine/argoClim2ioda.py.in
@@ -141,7 +141,7 @@ class IODA(object):
             'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         }
 
-        self.writer = iconv.NcWriter(self.filename, [], self.locKeyList)
+        self.writer = iconv.NcWriter(self.filename, self.locKeyList)
 
         # data is the dictionary containing IODA friendly data structure
         self.data = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -169,8 +169,8 @@ class IODA(object):
 
                     recKey += 1
 
-        (ObsVars, RecMdata, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
-        self.writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, self.AttrData)
+        (ObsVars, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
+        self.writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, self.AttrData)
 
         return
 

--- a/src/marine/cryosat_ice2ioda.py.in
+++ b/src/marine/cryosat_ice2ioda.py.in
@@ -118,7 +118,7 @@ def main():
 
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in
     ice = Observation(args.input, args.thin, fdate, writer)
@@ -126,8 +126,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/cryosat_ice2ioda_DBL.py.in
+++ b/src/marine/cryosat_ice2ioda_DBL.py.in
@@ -127,15 +127,15 @@ def main():
 
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in
     ice = Observation(args.input, args.thin, fdate, writer)
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/emc_ice2ioda.py.in
+++ b/src/marine/emc_ice2ioda.py.in
@@ -111,7 +111,7 @@ def main():
 
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in
     ice = Observation(args.input, args.thin, fdate, writer)
@@ -119,8 +119,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(ice.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/gds2_sst2ioda.py.in
+++ b/src/marine/gds2_sst2ioda.py.in
@@ -267,12 +267,11 @@ def main():
 
     # pass parameters to the IODA writer
     # (needed because we are bypassing ExtractObsData within BuildNetcdf)
-    writer._nrecs = 1
     writer._nvars = len(selected_names)
     writer._nlocs = obs_data[(selected_names[0], 'ObsValue')].shape[0]
 
     # use the writer class to create the final output file
-    writer.BuildNetcdf(obs_data, {}, loc_data, var_data, attr_data)
+    writer.BuildNetcdf(obs_data, loc_data, var_data, attr_data)
 
 
 if __name__ == '__main__':

--- a/src/marine/gmao_obs2ioda.py.in
+++ b/src/marine/gmao_obs2ioda.py.in
@@ -135,7 +135,7 @@ class IODA(object):
             print('No %s observations for IODA!' % varName)
             return
 
-        self.writer = iconv.NcWriter(self.filename, [], self.locKeyList)
+        self.writer = iconv.NcWriter(self.filename, self.locKeyList)
 
         self.keyDict = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
 
@@ -175,8 +175,8 @@ class IODA(object):
                 self.data[recKey][locKey][errKey] = oerr
                 self.data[recKey][locKey][qcKey] = 0
 
-        (ObsVars, RecMdata, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
-        self.writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, self.AttrData)
+        (ObsVars, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
+        self.writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, self.AttrData)
 
         return
 

--- a/src/marine/godae_profile2ioda.py.in
+++ b/src/marine/godae_profile2ioda.py.in
@@ -169,7 +169,7 @@ class IODA(object):
             'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         }
 
-        self.writer = iconv.NcWriter(self.filename, [], self.locKeyList)
+        self.writer = iconv.NcWriter(self.filename, self.locKeyList)
 
         self.keyDict = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
         for key in self.varDict.keys():
@@ -215,8 +215,8 @@ class IODA(object):
 
                 recKey += 1
 
-        (ObsVars, RecMdata, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
-        self.writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, self.AttrData)
+        (ObsVars, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
+        self.writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, self.AttrData)
 
         return
 

--- a/src/marine/godae_ship2ioda.py.in
+++ b/src/marine/godae_ship2ioda.py.in
@@ -118,7 +118,7 @@ class IODA(object):
             'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         }
 
-        self.writer = iconv.NcWriter(self.filename, [], self.locKeyList)
+        self.writer = iconv.NcWriter(self.filename, self.locKeyList)
 
         self.keyDict = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
         for key in self.varDict.keys():
@@ -160,8 +160,8 @@ class IODA(object):
                     self.data[recKey][locKey][errKey] = err
                     self.data[recKey][locKey][qcKey] = qc
 
-        (ObsVars, RecMdata, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
-        self.writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, self.AttrData)
+        (ObsVars, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
+        self.writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, self.AttrData)
 
         return
 

--- a/src/marine/godae_trak2ioda.py.in
+++ b/src/marine/godae_trak2ioda.py.in
@@ -114,7 +114,7 @@ class IODA(object):
             'date_time_string': self.date.strftime("%Y-%m-%dT%H:%M:%SZ")
         }
 
-        self.writer = iconv.NcWriter(self.filename, [], self.locKeyList)
+        self.writer = iconv.NcWriter(self.filename, self.locKeyList)
 
         self.keyDict = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
         for key in self.varDict.keys():
@@ -161,8 +161,8 @@ class IODA(object):
                     self.data[recKey][locKey][errKey] = err
                     self.data[recKey][locKey][qcKey] = qc
 
-        (ObsVars, RecMdata, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
-        self.writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, self.AttrData)
+        (ObsVars, LocMdata, VarMdata) = self.writer.ExtractObsData(self.data)
+        self.writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, self.AttrData)
 
         return
 

--- a/src/marine/hgodas_adt2ioda.py.in
+++ b/src/marine/hgodas_adt2ioda.py.in
@@ -93,7 +93,7 @@ def main():
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
 
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in the profiles
     prof = Observation(args.input, fdate, writer)
@@ -101,8 +101,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/hgodas_insitu2ioda.py.in
+++ b/src/marine/hgodas_insitu2ioda.py.in
@@ -100,16 +100,15 @@ def main():
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
 
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in the profiles
     prof = Profile(args.input, fdate, writer)
 
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/hgodas_sst2ioda.py.in
+++ b/src/marine/hgodas_sst2ioda.py.in
@@ -90,7 +90,7 @@ def main():
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
 
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in the profiles
     prof = Profile(args.input, fdate, writer)
@@ -98,8 +98,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/rads_adt2ioda.py.in
+++ b/src/marine/rads_adt2ioda.py.in
@@ -95,7 +95,7 @@ def main():
 
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in the altimeter
     altim = Observation(args.input, fdate, writer)
@@ -103,8 +103,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(altim.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(altim.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/marine/smap_sss2ioda.py.in
+++ b/src/marine/smap_sss2ioda.py.in
@@ -143,7 +143,7 @@ def main():
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
 
-    writer = iconv.NcWriter(args.output, [], locationKeyList)
+    writer = iconv.NcWriter(args.output, locationKeyList)
 
     # Read in the salinity
     sal = Salinity(args.input, fdate, writer)
@@ -151,8 +151,8 @@ def main():
     # write them out
     AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    (ObsVars, RecMdata, LocMdata, VarMdata) = writer.ExtractObsData(sal.data)
-    writer.BuildNetcdf(ObsVars, RecMdata, LocMdata, VarMdata, AttrData)
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(sal.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
 
 
 if __name__ == '__main__':

--- a/test/testoutput/amsua_aqua_obs_2018041500.nc4
+++ b/test/testoutput/amsua_aqua_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13e9e69e5acc9e1324c470d521321d71c68e9e8721ca7d950587d626d6acc48e
-size 167912
+oid sha256:35a8f47efd6f39d2d115bcc0fa8b76211cdeff1b9fd6cd79877da645096de83d
+size 166330

--- a/test/testoutput/argoclim.nc
+++ b/test/testoutput/argoclim.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2bc2d06ec2e23e65a6701e41979eea68ac9f0e77627e304a4f367abc5d514e6
-size 19603
+oid sha256:c41dd4ae995d9f9877403e61690786c51df81e6a4579dfc9dcf45f1e67e55cdf
+size 18579

--- a/test/testoutput/cryosat2_L2.nc
+++ b/test/testoutput/cryosat2_L2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91fb68d4ba8436ba4bf2e557a8ad842be2da15aaa6bd82371ccab52120ef881b
-size 18817
+oid sha256:712ad8daf4f80b9fe02145cc21b8ee29d432b23df6d3fcc539e8a2c7dc6db416
+size 18305

--- a/test/testoutput/cryosat2_L2_DBL.nc
+++ b/test/testoutput/cryosat2_L2_DBL.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2558f0190e8513b37c75537ec9129dad72c3fffe7a60ffd3bd8eb7cc3927548
-size 838449
+oid sha256:4567576dbd15973eddf1e0f79ac9ce192dde2018da17e79591c9ff9d4fd3ed00
+size 837937

--- a/test/testoutput/gds2_sst_l2p.nc
+++ b/test/testoutput/gds2_sst_l2p.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc92efe1162e7e0433c8c445d3ed69abf3ff4f8ddcc1f5bb66aab6b8d61c5014
-size 19719
+oid sha256:2787c6d303ac13ca04c43ab662ace9861c6a1ef01afc8de2b22a0ccd5cffddd6
+size 19404

--- a/test/testoutput/gds2_sst_l3u.nc
+++ b/test/testoutput/gds2_sst_l3u.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb6c23a813b8e9b6208a47926c7eeea5102ab89bb90def03a07387251623dcb8
-size 22591
+oid sha256:086042aa539c5250990ec61229d32857d01ff0fd2acb4b7864610f5b7bd0c760
+size 22276

--- a/test/testoutput/godae_prof.nc
+++ b/test/testoutput/godae_prof.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72f709cc6dcfcc17243af024e60f9359c0102f81fd4bed6a85461cf230899799
-size 20636
+oid sha256:a91f6944dc04e88faae32e8ab58a06c8d270ba2561318fb8989c80ed1707c92c
+size 20265

--- a/test/testoutput/godae_ship.nc
+++ b/test/testoutput/godae_ship.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d0b932d8838a656142f4bf58c893962a6b8fa44a93b9a0a6228d9fb5e759e80
-size 66938
+oid sha256:49d229eabe4ed01b23c028686a1b778d6fa4a632abd14925068c6c3dfa062c14
+size 64381

--- a/test/testoutput/godae_trak.nc
+++ b/test/testoutput/godae_trak.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1082caf4188335cb70ee07236fd542d5e3790efe9cfbf48aa472846294527526
-size 22496
+oid sha256:4eae90ff6f842820c989492caba502c0bcf648a7e7ee0242aac898a1219c470a
+size 22103

--- a/test/testoutput/hgodas_insitu.nc
+++ b/test/testoutput/hgodas_insitu.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63ce050d4e4bc150682da63d3be330a3d8e7b1c02f4a2f56b8e7c908a4db3171
-size 23156
+oid sha256:8c89445681baeb00bd54dc97fd4e2ef02294783df087addca39277921b9a51a5
+size 22329

--- a/test/testoutput/hgodas_sst.nc
+++ b/test/testoutput/hgodas_sst.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab5fefd5466a666f37c8d932a1771428429cbbbbbd4eed565f5e82641f3b3df1
-size 21676
+oid sha256:77a7367bb3f98d89213fb9e94d2c4e39b82bf3def5461841be9c68de21601557
+size 20635

--- a/test/testoutput/rads_adt.nc
+++ b/test/testoutput/rads_adt.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7eb88a9c589c0eea56b55c6cacb6e22081253bcdfae48163fdc35799ee7a7d7
-size 19710
+oid sha256:6df83e75db1a727ed9472c2c54087cd8d6d2ba4d4ba813ab76f686d1a049fa74
+size 19181

--- a/test/testoutput/sfc_tv_obs_2018041500.nc4
+++ b/test/testoutput/sfc_tv_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdf85f4b6be2955084f1881fe6e5860d0004488862a4403768ba45cc66850622
-size 27045
+oid sha256:559eea3880a1b7a3040cc6d506cde199a0ac8d636cec9e69392b8ba3ff3cdd1a
+size 24184

--- a/test/testoutput/smap_sss_rss.nc
+++ b/test/testoutput/smap_sss_rss.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:338bda05878a77b5e815d0101b1a36820d4ac8e9248e3e7203a304697f460356
-size 15187
+oid sha256:4cbcdc008fc523fd5bb6d3ce3614eff28d0adc77ae0fabc553167dca2215d74b
+size 14146


### PR DESCRIPTION
List of work performed in this PR:

(1) Removed the use of nrecs from IODA obs file (see changes in gsi_ncdiag.py and ioda_conv_ncio.py)
 
(2) Updated all python scripts under marine directory according to changes in (1)

(3) Updated all related output test observation files (test/testoutput) according to changes in (1) and confirmed that the nrecs were removed.