### PR TITLE
Bug fix for test fields  

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -406,7 +406,7 @@ units_values = {
 
 # @TestReference
 # fields from GSI to compare to computations done in UFO
-test_fields = {
+test_fields_ = {
 }
 test_fields_allsky = {
     'clwp_amsua': ('clw_retrieved_from_observation', 'float'),

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -402,6 +402,9 @@ units_values = {
     'brightness_temperature_jacobian_air_temperature': '1',
     'brightness_temperature_jacobian_humidity_mixing_ratio': 'K/g/Kg ',
     'optical_thickness_of_atmosphere_layer': '1',
+    'clw_retrieved_from_observation': 'kg/m/m',
+    'clw_retrieved_from_background': 'kg/m/m',
+    'scat_retrieved_from_observation': '1',
 }
 
 # @TestReference

--- a/test/testoutput/amsua_aqua_obs_2018041500.nc4
+++ b/test/testoutput/amsua_aqua_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35a8f47efd6f39d2d115bcc0fa8b76211cdeff1b9fd6cd79877da645096de83d
+oid sha256:a39105f79ad4816f7bc3122c687b5666ac27c061ae600a0d507656f8276119db
 size 166330


### PR DESCRIPTION
This is a follow-up PR for previous PR #257 
Three things:
(1)  A bug that prevented the @TestReference group written to obs file was found.
                      
      The list variable "test_fields" should be "test_fields_"

(2) Added units to variables in @TestReference group for radiance data

(3) Updated test output file for amsua_n19 obs file since units were added to variables in test fields.

