### PR TITLE
Feature/gsincdiag-performance

### DIFF
--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -6,21 +6,6 @@ list( APPEND programs
   combine_conv.py
   subset_files.py)
 
-# SET_TARGETS_DEPS( "${libs}"
-#                    ${CMAKE_CURRENT_SOURCE_DIR}
-#                    ${PYIODACONV_BUILD_LIBDIR}
-#                    gsi_ncdiag_scripts_deps)
-# add_custom_target( gsi_ncdiag_scripts ALL DEPENDS ${gsi_ncdiag_scripts_deps} )
-#
-# set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
-# CONF_TARGETS_DEPS( "${programs}"
-#                    ${CMAKE_CURRENT_SOURCE_DIR}
-#                    ${CMAKE_BINARY_DIR}/bin
-#                    bin_gsi_ncdiag_scripts_deps)
-# add_custom_target( bin_gsi_ncdiag_scripts ALL
-#     COMMAND chmod +x ${bin_gsi_ncdiag_scripts_deps}
-#     DEPENDS ${bin_gsi_ncdiag_scripts_deps} )
-
 foreach(_file IN LISTS programs)
     add_custom_target(${_file} ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${CMAKE_BINARY_DIR}/bin/${_file}
                                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})

--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -1,48 +1,37 @@
-list( APPEND libs
-  gsi_ncdiag.py
-)
+list(APPEND libs gsi_ncdiag.py)
 
 list( APPEND programs
   proc_gsi_ncdiag.py
   test_gsidiag.py
   combine_conv.py
-  subset_files.py
-)
+  subset_files.py)
 
-SET_TARGETS_DEPS( "${libs}"
-                   ${CMAKE_CURRENT_SOURCE_DIR}
-                   ${PYIODACONV_BUILD_LIBDIR}
-                   gsi_ncdiag_scripts_deps)
-add_custom_target( gsi_ncdiag_scripts ALL DEPENDS ${gsi_ncdiag_scripts_deps} )
+# SET_TARGETS_DEPS( "${libs}"
+#                    ${CMAKE_CURRENT_SOURCE_DIR}
+#                    ${PYIODACONV_BUILD_LIBDIR}
+#                    gsi_ncdiag_scripts_deps)
+# add_custom_target( gsi_ncdiag_scripts ALL DEPENDS ${gsi_ncdiag_scripts_deps} )
+#
+# set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
+# CONF_TARGETS_DEPS( "${programs}"
+#                    ${CMAKE_CURRENT_SOURCE_DIR}
+#                    ${CMAKE_BINARY_DIR}/bin
+#                    bin_gsi_ncdiag_scripts_deps)
+# add_custom_target( bin_gsi_ncdiag_scripts ALL
+#     COMMAND chmod +x ${bin_gsi_ncdiag_scripts_deps}
+#     DEPENDS ${bin_gsi_ncdiag_scripts_deps} )
 
-set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
-CONF_TARGETS_DEPS( "${programs}"
-                   ${CMAKE_CURRENT_SOURCE_DIR}
-                   ${CMAKE_BINARY_DIR}/bin
-                   bin_gsi_ncdiag_scripts_deps)
-add_custom_target( bin_gsi_ncdiag_scripts ALL
-    COMMAND chmod +x ${bin_gsi_ncdiag_scripts_deps}
-    DEPENDS ${bin_gsi_ncdiag_scripts_deps} )
+foreach(_file IN LISTS programs)
+    add_custom_target(${_file} ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${CMAKE_BINARY_DIR}/bin/${_file}
+                               DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+endforeach()
+foreach(_file IN LISTS libs)
+    add_custom_target(${_file} ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${CMAKE_BINARY_DIR}/lib/pyiodaconv/${_file}
+                               DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
+endforeach()
 
-# Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
-CONF_TARGETS_DEPS( "${programs}"
-                   ${CMAKE_CURRENT_SOURCE_DIR}
-                   ${CMAKE_BINARY_DIR}/install-bin
-                   install_bin_gsi_ncdiag_scripts_deps)
-add_custom_target( install_bin_gsi_ncdiag_scripts ALL
-    COMMAND chmod +x ${install_bin_gsi_ncdiag_scripts_deps}
-    DEPENDS ${install_bin_gsi_ncdiag_scripts_deps} )
-
-install( PROGRAMS
-  ${install_bin_gsi_ncdiag_scripts_deps}
-  DESTINATION bin
-)
-
-install( FILES
-  ${gsi_ncdiag_scripts_deps}
-  DESTINATION lib/pyiodaconv
-)
+install(PROGRAMS ${programs} DESTINATION bin)
+install(FILES ${libs} DESTINATION lib/pyiodaconv)
 
 ecbuild_add_test( TARGET iodaconv_gsi-ncdiag_coding_norms
                   TYPE SCRIPT

--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -10,8 +10,11 @@ import numpy as np
 import argparse
 from collections import defaultdict, OrderedDict
 import datetime as dt
+from pathlib import Path
 
-sys.path.append("@SCRIPT_LIB_PATH@")
+prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
+sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+
 import ioda_conv_ncio as iconv
 from orddicts import DefaultOrderedDict
 

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -5,6 +5,19 @@
 ###############################################################################
 ###############################################################################
 # dictionaries and lists
+
+import os
+from collections import defaultdict, OrderedDict
+from orddicts import DefaultOrderedDict
+
+import numpy as np
+import datetime as dt
+import netCDF4 as nc
+
+import ioda_conv_ncio as iconv
+
+__ALL__ = ['conv_platforms']
+
 conv_platforms = {
     "conv_ps": [
         'sfc',
@@ -493,12 +506,24 @@ test_fields_with_channels = {
     'NSST_Retrieval_check': ('nsstret_check', 'integer'),
 }
 
-###############################################################################
-###############################################################################
+
+class BaseGSI:
+    EPSILON = 9e-12
+    FLOAT_FILL = nc.default_fillvals['f4']
+    INT_FILL = nc.default_fillvals['i4']
+    @staticmethod
+    def _as_array(netcdf_var):
+        return np.array(netcdf_var[:])
+
+    def var(self, var_name):
+        """
+        Data array.  Return a numpy array based on variable name
+        """
+        return self._as_array(self.df[var_name])
 
 
 # conventional observations
-class Conv:
+class Conv(BaseGSI):
     """ class Conv - conventional observations
 
                 Use this class to read in conventional observations
@@ -510,10 +535,7 @@ class Conv:
       filename    - string path to file
       validtime   - datetime object of valid observation time
       nobs        - number of observations
-
-
-  """
-
+    """
     def __init__(self, filename):
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
@@ -532,8 +554,6 @@ class Conv:
             self.obsvars = [splitfname[i + 1]]
 
     def read(self):
-        import netCDF4 as nc
-        import datetime as dt
         # get valid time
         df = nc.Dataset(self.filename)
         tstr = str(df.getncattr('date_time'))
@@ -547,13 +567,11 @@ class Conv:
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
-     if model state fields are in the GSI diag file, create
-     GeoVaLs in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        GeoVaLs in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
         # get list of platforms to process for the given obstype
         try:
             platforms = conv_platforms[self.obstype]
@@ -573,8 +591,7 @@ class Conv:
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:
                     if (os.path.exists(outname)):
-                        print("File exists. Skipping and not overwriting:")
-                        print(outname)
+                        print("File exists. Skipping and not overwriting:%s" % outname)
                         continue
                 OutVars = []
                 InVars = []
@@ -585,11 +602,9 @@ class Conv:
 
                 idx = grabobsidx(self.df, p, v)
                 if (np.sum(idx) == 0):
-                    print("No matching observations for:")
-                    print("Platform:" + p + " Var:" + v)
+                    print("No matching observations for Platform:%s Var:%s" % (p, v))
                     continue
-                print(str(np.sum(idx))+" matching observations for:")
-                print("Platform:" + p + " Var:" + v)
+                print("Platform:%s Var:%s #Obs:%d" % (p, v, np.sum(idx)))
                 # set up output file
                 ncout = nc.Dataset(outname, 'w', format='NETCDF4')
                 ncout.setncattr(
@@ -629,16 +644,9 @@ class Conv:
 
     def toIODAobs(self, OutDir, clobber=True, platforms=None):
         """ toIODAobs(OutDir,clobber=True)
-     output observations from the specified GSI diag file
-     to the JEDI/IODA observation format
+        output observations from the specified GSI diag file
+        to the JEDI/IODA observation format
         """
-        import ioda_conv_ncio as iconv
-        import os
-        from collections import defaultdict, OrderedDict
-        from orddicts import DefaultOrderedDict
-        import numpy as np
-        import datetime as dt
-        import netCDF4 as nc
         if not platforms:
             # get list of platforms to process for the given obstype
             try:
@@ -660,8 +668,7 @@ class Conv:
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:
                     if (os.path.exists(outname)):
-                        print("File exists. Skipping and not overwriting:")
-                        print(outname)
+                        print("File exists. Skipping and not overwriting: %s" % outname)
                         continue
                 LocKeyList = []
                 TestKeyList = []
@@ -687,11 +694,9 @@ class Conv:
                 # grab obs to process
                 idx = grabobsidx(self.df, p, v)
                 if (np.sum(idx) == 0):
-                    print("No matching observations for:")
-                    print("Platform:" + p + " Var:" + v)
+                    print("No matching observations for Platform:%s Var:%s" % (p, v))
                     continue
-                print("Platform:" + p + " Var:" + v)
-                print(str(np.sum(idx))+" obs to process")
+                print("Platform:%s Var:%s #Obs:%d" % (p, v, np.sum(idx)))
 
                 writer = iconv.NcWriter(outname, LocKeyList, TestKeyList=TestKeyList)
 
@@ -702,11 +707,14 @@ class Conv:
                     varDict[value]['qcKey'] = value, writer.OqcName()
 
                 for o in range(len(outvars)):
-                    obsdata = self.df[conv_gsivarnames[v][o]][idx]
-                    obserr = 1.0 / self.df['Errinv_Input'][idx]
-                    obserr[obserr > 4e8] = nc.default_fillvals['f4']
+                    obsdata = self.var(conv_gsivarnames[v][o])[idx]
+                    obserr = self.var('Errinv_Input')[idx]
+                    mask = obserr < self.EPSILON
+                    obserr[~mask] = 1.0 / obserr[~mask]
+                    obserr[mask] = self.FLOAT_FILL
+                    obserr[obserr > 4e8] = self.FLOAT_FILL
                     try:
-                        obsqc = self.df['Prep_QC_Mark'][idx]
+                        obsqc = self.var('Prep_QC_Mark')[idx]
                     except BaseException:
                         obsqc = np.ones_like(obsdata) * 2
                     if (v == 'uv'):
@@ -716,6 +724,7 @@ class Conv:
 
                     for key, value in gsivars.items():
                         if key in self.df.variables:
+                            df_key = self.var(key)
                             gvname = outvars[o], value
                             # some special actions need to be taken depending on
                             # var name...
@@ -723,14 +732,17 @@ class Conv:
                                 if (checkuv[outvars[o]] != key[0]):
                                     continue
                             if "Errinv" in key:
-                                tmp = 1.0 / self.df[key][idx]
+                                tmp = df_key[idx]
+                                mask = tmp < self.EPSILON
+                                tmp[~mask] = 1.0 / tmp[~mask]
+                                tmp[mask] = self.FLOAT_FILL
                             else:
-                                tmp = self.df[key][idx]
+                                tmp = df_key[idx]
                             if value in gsiint:
                                 tmp = tmp.astype(int)
-                                tmp[tmp > 4e4] = nc.default_fillvals['i4']
+                                tmp[tmp > 4e4] = self.INT_FILL
                             else:
-                                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                                tmp[tmp > 4e8] = self.FLOAT_FILL
                             outdata[gvname] = tmp
                     # store values in output data dictionary
                     outdata[varDict[outvars[o]]['valKey']] = obsdata
@@ -740,42 +752,42 @@ class Conv:
                 for lvar in LocVars:
                     loc_mdata_name = all_LocKeyList[lvar][0]
                     if lvar == 'Station_ID':
-                        tmp = self.df[lvar][idx]
+                        tmp = self.var(lvar)[idx]
                         StationIDs = [b''.join(tmp[a]) for a in range(len(tmp))]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(StationIDs, "string")
                     elif lvar == 'Time':  # need to process into time stamp strings #"%Y-%m-%dT%H:%M:%SZ"
-                        tmp = self.df[lvar][idx]
+                        tmp = self.var(lvar)[idx]
                         obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                         obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
                     # special logic for missing station_elevation and height for surface obs
                     elif lvar in ['Station_Elevation', 'Height']:
                         if p == 'sfc':
-                            tmp = self.df[lvar][idx]
-                            tmp[tmp == 9999.] = nc.default_fillvals['f4']
-                            tmp[tmp == 10009.] = nc.default_fillvals['f4']  # for u,v sfc Height values that are 10+9999
+                            tmp = self.var(lvar)[idx]
+                            tmp[tmp == 9999.] = self.FLOAT_FILL
+                            tmp[tmp == 10009.] = self.FLOAT_FILL  # for u,v sfc Height values that are 10+9999
                             # GSI sfc obs are at 0m agl, but operator assumes 2m agl, correct output to 2m agl
                             # this is correctly 10m agl though for u,v obs
                             if lvar == 'Height' and self.obstype in ['conv_t', 'conv_q']:
-                                elev = self.df['Station_Elevation'][idx]
+                                elev = self.var('Station_Elevation')[idx]
                                 hgt = elev + 2.
-                                hgt[hgt > 9998.] = nc.default_fillvals['f4']
+                                hgt[hgt > 9998.] = self.FLOAT_FILL
                                 tmp = hgt
                             loc_mdata[loc_mdata_name] = tmp
                         elif p == 'sondes' or p == 'aircraft' or p == 'satwind':
-                            tmp = self.df[lvar][idx]
-                            tmp[tmp > 4e8] = nc.default_fillvals['f4']  # 1e11 is fill value for sondes, etc.
+                            tmp = self.var(lvar)[idx]
+                            tmp[tmp > 4e8] = self.FLOAT_FILL  # 1e11 is fill value for sondes, etc.
                             loc_mdata[loc_mdata_name] = tmp
                         else:
-                            loc_mdata[loc_mdata_name] = self.df[lvar][idx]
+                            loc_mdata[loc_mdata_name] = self.var(lvar)[idx]
                     else:
-                        loc_mdata[loc_mdata_name] = self.df[lvar][idx]
+                        loc_mdata[loc_mdata_name] = self.var(lvar)[idx]
                 # put the TestReference fields in the structure for writing out
                 for tvar in TestVars:
                     if tvar in test_fields_:
                         test_mdata_name = test_fields_[tvar][0]
-                        tmp = self.df[tvar][idx]
-                        tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                        tmp = self.var(tvar)[idx]
+                        tmp[tmp > 4e8] = self.FLOAT_FILL
                         test_mdata[test_mdata_name] = tmp
                 # record info
                 SIDUnique, idxs, invs = np.unique(StationIDs, return_index=True, return_inverse=True, axis=0)
@@ -795,8 +807,7 @@ class Conv:
 
                 writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values, test_mdata)
 
-                print(str(len(obsdata))+" Conventional obs processed, wrote to:")
-                print(outname)
+                print("ProcessedL %d Conventional obs processed to: %s" % (len(obsdata), outname))
 
 
 def grabobsidx(obsdata, platform, var):
@@ -807,8 +818,6 @@ def grabobsidx(obsdata, platform, var):
 
     returns idx - indices of observations to write out
     """
-    import numpy as np
-
     code = obsdata['Observation_Type'][:]
     if var in ['tsen', 'tv']:
         iqt = obsdata['Setup_QC_Mark'][:]
@@ -836,7 +845,7 @@ def grabobsidx(obsdata, platform, var):
 
 
 # satellite radiance observations
-class Radiances:
+class Radiances(BaseGSI):
     """ class Radiances - satellite radiance observations
 
                 Use this class to read in satellite radiance observations
@@ -850,7 +859,7 @@ class Radiances:
       nobs        - number of observations
 
 
-  """
+    """
 
     def __init__(self, filename):
         self.filename = filename
@@ -864,8 +873,6 @@ class Radiances:
             raise ValueError("Observation is not a radiance type...")
 
     def read(self):
-        import netCDF4 as nc
-        import datetime as dt
         # get valid time
         df = nc.Dataset(self.filename)
         tstr = str(df.getncattr('date_time'))
@@ -883,14 +890,11 @@ class Radiances:
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
-     if model state fields are in the GSI diag file, create
-     GeoVaLs in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        GeoVaLs in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
-
         # set up output file
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
             '_geoval_' + self.validtime.strftime("%Y%m%d%H") + '.nc4'
@@ -943,21 +947,18 @@ class Radiances:
 
     def toObsdiag(self, OutDir, clobber=True):
         """ toObsdiag(OutDir,clobber=True)
-     if model state fields are in the GSI diag file, create
-     Obsdiag in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        Obsdiag in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
 
         # set up output file
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
             '_obsdiag_' + self.validtime.strftime("%Y%m%d%H") + '.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         OutVars = []
         InVars = []
@@ -981,9 +982,9 @@ class Radiances:
         ncout.createDimension("nlevs", self.df.dimensions["air_pressure_arr_dim"].size)
 
         # get channel info and list
-        chan_number = self.df['sensor_chan'][:]
+        chan_number = self.darr('sensor_chan')
         chan_number = chan_number[chan_number >= 0]
-        chan_indx = self.df['Channel_Index'][:]
+        chan_indx = self.var('Channel_Index')
         nchans = len(chan_number)
         nlocs = int(self.nobs / nchans)
         chanlist = chan_number
@@ -1005,8 +1006,7 @@ class Radiances:
                         var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
                         idx = chan_indx == c+1
                         if (np.sum(idx) == 0):
-                            print("No matching observations for:")
-                            print(value)
+                            print("No matching observations for: %s" % value)
                             continue
                         var_out = ncout.createVariable(var_name, var.dtype, dims)
                         vdata = var[:]
@@ -1020,8 +1020,7 @@ class Radiances:
                         var_name = obsdiag_vars[vname]+"_"+"{:d}".format(chanlist[c])
                         idx = chan_indx == c+1
                         if (np.sum(idx) == 0):
-                            print("No matching observations for:")
-                            print(value)
+                            print("No matching observations for: %s" % value)
                             continue
                         var_out = ncout.createVariable(var_name, var.dtype, dims)
                         vdata = var[...]
@@ -1033,27 +1032,17 @@ class Radiances:
 
     def toIODAobs(self, OutDir, ObsBias, QCVars, TestRefs, clobber=True):
         """ toIODAobs(OutDir,clobber=True)
-     output observations from the specified GSI diag file
-     to the JEDI/IODA observation format
+        output observations from the specified GSI diag file
+        to the JEDI/IODA observation format
         """
-        import ioda_conv_ncio as iconv
-        import os
-        from collections import defaultdict, OrderedDict
-        from orddicts import DefaultOrderedDict
-        import numpy as np
-        import datetime as dt
-        import netCDF4 as nc
 
-        print("Input Parameter: ObsBias =", ObsBias)
-        print("Input Parameter: QCVars =", QCVars)
-        print("Input Parameter: TestRefs =", TestRefs)
+        print("Input Parameters: ObsBias=%s QCVars=%s TestRefs=%s" % (ObsBias, QCVars, TestRefs))
         # set up a NcWriter class
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
             '_obs_' + self.validtime.strftime("%Y%m%d%H") + '.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         LocKeyList = []
         TestKeyList = []
@@ -1096,9 +1085,9 @@ class Radiances:
         else:
             writer = iconv.NcWriter(outname, LocKeyList)
 
-        chan_number = self.df['sensor_chan'][:]
+        chan_number = self.var('sensor_chan')
         chan_number = chan_number[chan_number >= 0]
-        chan_indx = self.df['Channel_Index'][:]
+        chan_indx = self.var('Channel_Index')
         nchans = len(chan_number)
         nlocs = int(self.nobs / nchans)
 
@@ -1129,9 +1118,9 @@ class Radiances:
                     varDict[vbc]['bctKey'] = vbc, writer.ObiastermName()
                     varDict[vbc]['bcpKey'] = vbc, writer.ObiaspredName()
                     ibc += 1
-        obsdata = self.df['Observation'][:]
-        obserr = self.df['Input_Observation_Error'][:]
-        obsqc = self.df['QC_Flag'][:].astype(int)
+        obsdata = self.var('Observation')
+        obserr = self.var('Input_Observation_Error')
+        obsqc = self.var('QC_Flag').astype(int)
         if (ObsBias):
             nametbc = [
                 'BC_Constant',
@@ -1164,24 +1153,24 @@ class Radiances:
             obsbiasterm = []
             ii = 0
             for nbc in nametbc:
-                obsbiasterm.append(self.df[nametbc[ii]][:])
+                obsbiasterm.append(self.var(nametbc[ii]))
                 ii += 1
 
             obsbiaspred = []
             ii = 0
             for nbc in namepbc:
-                obsbiaspred.append(self.df[namepbc[ii]][:])
+                obsbiaspred.append(self.var(namepbc[ii]))
                 ii += 1
         for lvar in LocVars:
             loc_mdata_name = all_LocKeyList[lvar][0]
             if lvar == 'Obs_Time':
-                tmp = self.df[lvar][::nchans]
+                tmp = self.var(lvar)[::nchans]
                 obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
             else:
-                tmp = self.df[lvar][::nchans]
-                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                tmp = self.var(lvar)[::nchans]
+                tmp[tmp > 4e8] = self.FLOAT_FILL
                 loc_mdata[loc_mdata_name] = tmp
 
         # put the TestReference fields in the structure for writing out
@@ -1189,16 +1178,15 @@ class Radiances:
             if tvar in test_fields_with_channels_:
                 for ii, ch in enumerate(chanlist):
                     test_mdata_name = test_fields_with_channels_[tvar][0]+"_{:d}".format(ch)
-                #   tmp = self.df[tvar][::nchans]
-                    tmp = self.df[tvar][:]
-                    tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                    tmp = self.var(tvar)[:]
+                    tmp[tmp > 4e8] = self.FLOAT_FILL
                     idx = chan_indx == ii+1
                     outvals = tmp[idx]
                     test_mdata[test_mdata_name] = outvals
             if tvar in test_fields_:
                 test_mdata_name = test_fields_[tvar][0]
-                tmp = self.df[tvar][::nchans]
-                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                tmp = self.var(tvar)[::nchans]
+                tmp[tmp > 4e8] = self.FLOAT_FILL
                 test_mdata[test_mdata_name] = tmp
 
         gsi_add_radvars = gsi_add_vars
@@ -1219,17 +1207,17 @@ class Radiances:
         for gsivar, iodavar in gsi_add_radvars.items():
             if gsivar in self.df.variables:
                 if "Inverse" in gsivar:
-                    tmp2 = self.df[gsivar][:]
+                    tmp = self.var(gsivar)
                     # fix for if some reason 1/small does not result in inf but zero
-                    tmp2[tmp2 < 9e-12] = 0
-                    tmp = 1.0 / tmp2
-                    tmp[np.isinf(tmp)] = nc.default_fillvals['f4']
+                    mask = tmp < self.EPSILON
+                    tmp[~mask] = 1.0 / tmp[~mask]
+                    tmp[mask] = self.FLOAT_FILL
                 else:
-                    tmp = self.df[gsivar][:]
+                    tmp = self.var(gsivar)
                 if gsivar in gsiint:
                     tmp = tmp.astype(int)
                 else:
-                    tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                    tmp[tmp > 4e8] = self.FLOAT_FILL
                 for ii, ch in enumerate(chanlist):
                     varname = "brightness_temperature_{:d}".format(ch)
                     gvname = varname, iodavar
@@ -1244,14 +1232,13 @@ class Radiances:
             var_names.append(value)
             idx = chan_indx == c+1
             if (np.sum(idx) == 0):
-                print("No matching observations for:")
-                print(value)
+                print("No matching observations for: %s" % value)
                 continue
             obsdatasub = obsdata[idx]
-            obsdatasub[obsdatasub > 9e5] = nc.default_fillvals['f4']
+            obsdatasub[obsdatasub > 9e5] = self.FLOAT_FILL
             obserrsub = obserr[idx]
             obsqcsub = obsqc[idx]
-            obsqcsub[obsdatasub > 9e5] = nc.default_fillvals['i4']
+            obsqcsub[obsdatasub > 9e5] = self.INT_FILL
 
             # store values in output data dictionary
             outdata[varDict[value]['valKey']] = obsdatasub
@@ -1276,8 +1263,8 @@ class Radiances:
                 for value in valuebc:
                     obsbiastermsub = obsbiasterm[ii][idx]
                     obsbiaspredsub = obsbiaspred[ii][idx]
-                    obsbiastermsub[obsbiastermsub > 9e5] = nc.default_fillvals['f4']
-                    obsbiaspredsub[obsbiaspredsub > 9e5] = nc.default_fillvals['f4']
+                    obsbiastermsub[obsbiastermsub > 9e5] = self.FLOAT_FILL
+                    obsbiaspredsub[obsbiaspredsub > 9e5] = self.FLOAT_FILL
 
                     # store values in output data dictionary
                     outdata[varDict[value]['bctKey']] = obsbiastermsub
@@ -1287,7 +1274,7 @@ class Radiances:
         var_mdata['variable_names'] = writer.FillNcVector(var_names, "string")
         for key, value2 in chan_metadata_dict.items():
             try:
-                var_mdata[value2] = self.df[key][:]
+                var_mdata[value2] = self.var(key)
             except IndexError:
                 pass
 
@@ -1311,27 +1298,23 @@ class Radiances:
             writer.BuildNetcdf(outdata, loc_mdata, var_mdata,
                                AttrData, units_values)
 
-        print("Satellite radiance obs processed, wrote to:")
-        print(outname)
+        print("Satellite radiance obs processed, wrote to: %s" % outname)
 
 
 # atmospheric composition observations
 
-class AOD:
+class AOD(BaseGSI):
     """ class AOD - aerosol optical depth satellite observations
 
-              Use this class to read in AOD satellite observations
-              from GSI netCDF diag files
+        Use this class to read in AOD satellite observations
+        from GSI netCDF diag files
 
-  Functions:
-
-  Attributes:
-    filename    - string path to file
-    validtime   - datetime object of valid observation time
-    nobs        - number of observations
-
-
-"""
+    Functions:
+    Attributes:
+        filename    - string path to file
+        validtime   - datetime object of valid observation time
+        nobs        - number of observations
+    """
     def __init__(self, filename):
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
@@ -1347,8 +1330,6 @@ class AOD:
         self.satellite = splitfname[i+2]
 
     def read(self):
-        import netCDF4 as nc
-        import datetime as dt
         # get valid time
         df = nc.Dataset(self.filename)
         tstr = str(df.getncattr('date_time'))
@@ -1360,20 +1341,17 @@ class AOD:
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
- if model state fields are in the GSI diag file, create
- GeoVaLs in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        GeoVaLs in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
 
         # set up output file
         outname = OutDir+'/'+self.obstype+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         OutVars = []
         InVars = []
@@ -1415,22 +1393,16 @@ class AOD:
         ncout.close()
 
     def toIODAobs(self, OutDir, clobber=True):
-        """ toIODAobs(OutDir,clobber=True)
-   output observations from the specified GSI diag file
-   to the JEDI/IODA observation format
-"""
-        import ioda_conv_ncio as iconv
-        import os
-        from collections import defaultdict, OrderedDict
-        from orddicts import DefaultOrderedDict
-        import numpy as np
-        import datetime as dt
+        """
+        toIODAobs(OutDir,clobber=True)
+        output observations from the specified GSI diag file
+        to the JEDI/IODA observation format
+        """
         # set up a NcWriter class
         outname = OutDir+'/'+self.obstype+'_obs_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting:%s" % outname)
                 return
         LocKeyList = []
         LocVars = []
@@ -1448,9 +1420,9 @@ class AOD:
         # for now, record len is 1 and the list is empty?
         writer = iconv.NcWriter(outname, LocKeyList)
 
-        chan_number = self.df['sensor_chan'][:]
+        chan_number = self.var('sensor_chan')
         chan_number = chan_number[chan_number >= 0]
-        chan_indx = self.df['Channel_Index'][:]
+        chan_indx = self.var('Channel_Index')
         nchans = len(chan_number)
         nlocs = self.nobs / nchans
         chanlist = chan_indx[:nchans]
@@ -1460,9 +1432,9 @@ class AOD:
             varDict[value]['errKey'] = value, writer.OerrName()
             varDict[value]['qcKey'] = value, writer.OqcName()
 
-        obsdata = self.df['Observation'][:]
-        obserr = 1.0/self.df['Observation_Error'][:]
-        obsqc = self.df['QC_Flag'][:].astype(int)
+        obsdata = self.var('Observation')
+        obserr = 1.0/self.var('Observation_Error')
+        obsqc = self.var('QC_Flag').astype(int)
 
         gsivars = gsi_add_vars
 
@@ -1478,23 +1450,23 @@ class AOD:
             for lvar in LocVars:
                 loc_mdata_name = all_LocKeyList[lvar][0]
                 if lvar == 'Obs_Time':
-                    tmp = self.df[lvar][idx]
+                    tmp = self.var(lvar)[idx]
                     obstimes = [self.validtime+dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                     obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                     loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
                 else:
-                    loc_mdata[loc_mdata_name] = self.df[lvar][idx]
+                    loc_mdata[loc_mdata_name] = self.var(lvar)[idx]
             gsimeta = {}
             for key, value2 in gsivars.items():
                 # some special actions need to be taken depending on var name...
                 if "Inverse" in key:
                     try:
-                        gsimeta[key] = 1.0/self.df[key][idx]
+                        gsimeta[key] = 1.0/self.var(key)[idx]
                     except IndexError:
                         pass
                 else:
                     try:
-                        gsimeta[key] = self.df[key][idx]
+                        gsimeta[key] = self.var(key)[idx]
                     except IndexError:
                         pass
 
@@ -1521,7 +1493,7 @@ class AOD:
         var_mdata['variable_names'] = writer.FillNcVector(var_names, "string")
         for key, value2 in chan_metadata_dict.items():
             try:
-                var_mdata[value2] = self.df[key][:nchans]
+                var_mdata[value2] = self.var(key)[:nchans]
             except IndexError:
                 pass
 
@@ -1538,11 +1510,10 @@ class AOD:
         writer._nlocs = nlocs
 
         writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
-        print("AOD obs processed, wrote to:")
-        print(outname)
+        print("AOD obs processed, wrote to:%s" % outname)
 
 
-class Ozone:
+class Ozone(BaseGSI):
     """ class Ozone - ozone satellite observations
 
                 Use this class to read in ozone satellite observations
@@ -1555,7 +1526,7 @@ class Ozone:
       validtime   - datetime object of valid observation time
       nobs        - number of observations
 
-"""
+    """
     def __init__(self, filename):
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
@@ -1571,8 +1542,6 @@ class Ozone:
         self.satellite = splitfname[i+1]
 
     def read(self):
-        import netCDF4 as nc
-        import datetime as dt
         # get valid time
         df = nc.Dataset(self.filename)
         tstr = str(df.getncattr('date_time'))
@@ -1583,20 +1552,17 @@ class Ozone:
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
-   if model state fields are in the GSI diag file, create
-   GeoVaLs in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        GeoVaLs in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
 
         # set up output file
         outname = OutDir+'/'+self.sensor+'_'+self.satellite+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         OutVars = []
         InVars = []
@@ -1639,22 +1605,14 @@ class Ozone:
 
     def toIODAobs(self, OutDir, clobber=True):
         """ toIODAobs(OutDir,clobber=True)
-   output observations from the specified GSI diag file
-   to the JEDI/IODA observation format
+        output observations from the specified GSI diag file
+        to the JEDI/IODA observation format
         """
-        import ioda_conv_ncio as iconv
-        import netCDF4 as nc
-        import os
-        from collections import defaultdict, OrderedDict
-        from orddicts import DefaultOrderedDict
-        import numpy as np
-        import datetime as dt
         # set up a NcWriter class
         outname = OutDir+'/'+self.sensor+'_'+self.satellite+'_obs_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         LocKeyList = []
         LocVars = []
@@ -1677,40 +1635,40 @@ class Ozone:
         varDict[vname]['errKey'] = vname, writer.OerrName()
         varDict[vname]['qcKey'] = vname, writer.OqcName()
 
-        obsdata = self.df['Observation'][:]
-        tmp = self.df['Input_Observation_Error'][:]
-        tmp[tmp < 9e-12] = 0
+        obsdata = self.var('Observation')
+        tmp = self.var('Input_Observation_Error')
+        tmp[tmp < self.EPSILON] = 0
         obserr = tmp
-        obserr[np.isinf(obserr)] = nc.default_fillvals['f4']
-        obsqc = self.df['Analysis_Use_Flag'][:].astype(int)
+        obserr[np.isinf(obserr)] = self.FLOAT_FILL
+        obsqc = self.var('Analysis_Use_Flag').astype(int)
         locKeys = []
         for lvar in LocVars:
             loc_mdata_name = all_LocKeyList[lvar][0]
             if lvar == 'Time':
-                tmp = self.df[lvar][:]
+                tmp = self.var(lvar)
                 obstimes = [self.validtime+dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
             else:
-                tmp = self.df[lvar][:]
-                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                tmp = self.var(lvar)
+                tmp[tmp > 4e8] = self.FLOAT_FILL
                 loc_mdata[loc_mdata_name] = tmp
 
         for gsivar, iodavar in gsi_add_vars.items():
             # some special actions need to be taken depending on var name...
             if gsivar in self.df.variables:
                 if "Inverse" in gsivar:
-                    tmp2 = self.df[gsivar][:]
+                    tmp = self.var(gsivar)
                     # fix for if some reason 1/small does not result in inf but zero
-                    tmp2[tmp2 < 9e-12] = 0
-                    tmp = 1.0 / tmp2
-                    tmp[np.isinf(tmp)] = nc.default_fillvals['f4']
+                    mask = tmp < self.EPSILON
+                    tmp[~mask] = 1.0 / tmp[~mask]
+                    tmp[mask] = self.FLOAT_FILL
                 else:
-                    tmp = self.df[gsivar][:]
+                    tmp = self.var(gsivar)
                 if gsivar in gsiint:
                     tmp = tmp.astype(int)
                 else:
-                    tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                    tmp[tmp > 4e8] = self.FLOAT_FILL
                 gvname = vname, iodavar
                 outdata[gvname] = tmp
         # observation data
@@ -1730,11 +1688,10 @@ class Ozone:
         writer._nlocs = nlocs
 
         writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
-        print("Ozone obs processed, wrote to:")
-        print(outname)
+        print("Ozone obs processed, wrote to: %s" % outname)
 
 
-class Radar:
+class Radar(BaseGSI):
     """ class Radar - reflectivity and radial wind observations
 
                 Use this class to read in radar observations
@@ -1747,7 +1704,7 @@ class Radar:
       validtime   - datetime object of valid observation time
       nobs        - number of observations
 
-"""
+    """
     def __init__(self, filename):
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
@@ -1763,8 +1720,6 @@ class Radar:
         self.obstype = splitfname[i+1]
 
     def read(self):
-        import netCDF4 as nc
-        import datetime as dt
         # get valid time
         df = nc.Dataset(self.filename)
         tstr = str(df.getncattr('date_time'))
@@ -1775,20 +1730,17 @@ class Radar:
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
-   if model state fields are in the GSI diag file, create
-   GeoVaLs in an output file for use by JEDI/UFO
+        if model state fields are in the GSI diag file, create
+        GeoVaLs in an output file for use by JEDI/UFO
         """
         # note, this is a temporary construct and thus, there is no
         # ioda_conv_ncio or equivalent to handle the format
-        import numpy as np
-        import netCDF4 as nc
 
         # set up output file
         outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         OutVars = []
         InVars = []
@@ -1829,22 +1781,14 @@ class Radar:
 
     def toIODAobs(self, OutDir, clobber=True):
         """ toIODAobs(OutDir,clobber=True)
-   output observations from the specified GSI diag file
-   to the JEDI/IODA observation format
+        output observations from the specified GSI diag file
+        to the JEDI/IODA observation format
         """
-        import ioda_conv_ncio as iconv
-        import netCDF4 as nc
-        import os
-        from collections import defaultdict, OrderedDict
-        from orddicts import DefaultOrderedDict
-        import numpy as np
-        import datetime as dt
         # set up a NcWriter class
         outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_obs_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
         if not clobber:
             if (os.path.exists(outname)):
-                print("File exists. Skipping and not overwriting:")
-                print(outname)
+                print("File exists. Skipping and not overwriting:%s" % outname)
                 return
         LocKeyList = []
         LocVars = []
@@ -1876,15 +1820,12 @@ class Radar:
             varDict[value]['errKey'] = value, writer.OerrName()
             varDict[value]['qcKey'] = value, writer.OqcName()
 
-            obsdata = self.df[key][:]
-            # tmp = self.df['Inverse_Observation_Error'][:]
-            # tmp[tmp < 9e-12] = 0
-            # obserr = 1.0 / tmp
+            obsdata = self.var(key)
             errvarname = radar_err[key]
             qcvarname = radar_qc[key]
-            obserr = self.df[errvarname][:]
-            obserr[np.isinf(obserr)] = nc.default_fillvals['f4']
-            obsqc = self.df[qcvarname][:].astype(int)
+            obserr = self.var(errvarname)
+            obserr[np.isinf(obserr)] = self.FLOAT_FILL
+            obsqc = self.var(qcvarname).astype(int)
             # observation data
             outdata[varDict[value]['valKey']] = obsdata
             outdata[varDict[value]['errKey']] = obserr
@@ -1894,30 +1835,30 @@ class Radar:
                 # some special actions need to be taken depending on var name...
                 if gsivar in self.df.variables:
                     if "Inverse" in gsivar:
-                        tmp2 = self.df[gsivar][:]
+                        tmp = self.var(gsivar)
                         # fix for if some reason 1/small does not result in inf but zero
-                        tmp2[tmp2 < 9e-12] = 0
-                        tmp = 1.0 / tmp2
-                        tmp[np.isinf(tmp)] = nc.default_fillvals['f4']
+                        mask = tmp < self.EPSILON
+                        tmp[~mask] = 1.0 / tmp[~mask]
+                        tmp[mask] = self.FLOAT_FILL
                     else:
-                        tmp = self.df[gsivar][:]
+                        tmp = self.var(gsivar)[:]
                     if gsivar in gsiint:
                         tmp = tmp.astype(int)
                     else:
-                        tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                        tmp[tmp > 4e8] = self.FLOAT_FILL
                     gvname = vname, iodavar
                     outdata[gvname] = tmp
         locKeys = []
         for lvar in LocVars:
             loc_mdata_name = all_LocKeyList[lvar][0]
             if lvar == 'Time':
-                tmp = self.df[lvar][:]
+                tmp = self.var(lvar)[:]
                 obstimes = [self.validtime+dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
             else:
-                tmp = self.df[lvar][:]
-                tmp[tmp > 4e8] = nc.default_fillvals['f4']
+                tmp = self.var(lvar)[:]
+                tmp[tmp > 4e8] = self.FLOAT_FILL
                 loc_mdata[loc_mdata_name] = tmp
 
         # dummy record metadata, for now
@@ -1931,5 +1872,4 @@ class Radar:
         writer._nlocs = nlocs
 
         writer.BuildNetcdf(outdata, loc_mdata, var_mdata, AttrData, units_values)
-        print("Radar obs processed, wrote to:")
-        print(outname)
+        print("Radar obs processed, wrote to: %s" % outname)

--- a/src/gsi-ncdiag/proc_gsi_ncdiag.py
+++ b/src/gsi-ncdiag/proc_gsi_ncdiag.py
@@ -2,87 +2,106 @@
 import argparse
 import os
 import sys
-from multiprocessing import Pool
 import glob
+import time
+from multiprocessing import Pool
+from pathlib import Path
 
-sys.path.append("@SCRIPT_LIB_PATH@")
+prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
+sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+
 import gsi_ncdiag as gsid
 
 
 def run_conv_obs(convfile, outdir, platforms):
     print("Processing:"+str(convfile))
+    startt = time.time()
     Diag = gsid.Conv(convfile)
     Diag.read()
     Diag.toIODAobs(outdir, platforms=platforms)
     Diag.close()
+    print("Time (OBS) %s[%s]: %.3g sec" % (covfile, ",".join(platforms), time.time() - startt))
     return 0
 
 
 def run_radiances_obs(radfile, outdir, obsbias, qcvars, testrefs):
-    print("Processing run_radiances_obs:")
-    print("Processing:"+str(radfile))
+    print("Processing run_radiances_obs:%s" % radfile)
+    startt = time.time()
     Diag = gsid.Radiances(radfile)
     Diag.read()
     Diag.toIODAobs(outdir, obsbias, qcvars, testrefs)
     Diag.close()
+    print("Time (OBS) %s: %.3g sec" % (radfile, time.time() - startt))
     return 0
 
 
 def run_aod_obs(aodfile, outdir):
     print("Processing:"+str(aodfile))
+    startt = time.time()
     Diag = gsid.AOD(aodfile)
     Diag.read()
     Diag.toIODAobs(outdir)
+    print("Time (OBS) %s: %.3g sec" % (aodfile, time.time() - startt))
     return 0
 
 
 def run_oz_obs(ozfile, outdir):
     print("Processing:"+str(ozfile))
+    startt = time.time()
     Diag = gsid.Ozone(ozfile)
     Diag.read()
     Diag.toIODAobs(outdir)
+    print("Time (OBS) %s: %.3g sec" % (ozfile, time.time() - startt))
     return 0
 
 
 def run_conv_geo(convfile, outdir):
     print("Processing:"+str(convfile))
+    startt = time.time()
     Diag = gsid.Conv(convfile)
     Diag.read()
     Diag.toGeovals(outdir)
+    print("Time (GEO) %s: %.3g sec" % (convfile, time.time() - startt))
     return 0
 
 
 def run_radiances_geo(radfile, outdir):
-    print("Processing run_radiances_geo:")
-    print("Processing:"+str(radfile))
+    print("Processing run_radiances_geo:%s" % radfile)
+    startt = time.time()
     Diag = gsid.Radiances(radfile)
     Diag.read()
     Diag.toGeovals(outdir)
+    print("Time (GEO) %s: %.3g sec" % (radfile, time.time() - startt))
     return 0
 
 
 def run_aod_geo(aodfile, outdir):
     print("Processing:"+str(aodfile))
+    startt = time.time()
     Diag = gsid.AOD(aodfile)
     Diag.read()
     Diag.toGeovals(outdir)
+    print("Time (GEO) %s: %.3g sec" % (aodfile, time.time() - startt))
     return 0
 
 
 def run_oz_geo(ozfile, outdir):
     print("Processing:"+str(ozfile))
+    startt = time.time()
     Diag = gsid.Ozone(ozfile)
     Diag.read()
     Diag.toGeovals(outdir)
+    print("Time (GEO) %s: %.3g sec" % (ozfile, time.time() - startt))
     return 0
 
 
 def run_radiances_obsdiag(radfile, outdir):
-    print("Processing run_radiances_obsdiag:")
-    print("Processing:"+str(radfile))
+    print("Processing run_radiances_obsdiag: %s" % radfile)
+    startt = time.time()
     Diag = gsid.Radiances(radfile)
     Diag.read()
     Diag.toObsdiag(outdir)
+    print("Time (DIAG) %s: %.3g sec" % (radfile, time.time() - startt))
     return 0
 
 
@@ -115,10 +134,13 @@ else:
 
 DiagDir = MyArgs.input_dir
 
+print("Proc GSI Using %d processors." % nprocs)
 obspool = Pool(processes=nprocs)
 # process obs files
 if MyArgs.obs_dir:
     ObsDir = MyArgs.obs_dir
+    if not Path(ObsDir).is_dir():
+        raise Exception("Obs dir: '%s' does not exist." % ObsDir)
     ObsBias = MyArgs.add_obsbias
     QCVars = MyArgs.add_qcvars
     TestRefs = MyArgs.add_testrefs

--- a/src/gsi-ncdiag/test_gsidiag.py
+++ b/src/gsi-ncdiag/test_gsidiag.py
@@ -2,8 +2,11 @@
 # script to run to test if the GSI ncdiag converters are still working
 import sys
 import argparse
+from pathlib import Path
 
-sys.path.append("@SCRIPT_LIB_PATH@")
+prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
+sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+
 import gsi_ncdiag as gsid
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
 Performance and warning cleanup for ncdiag converters
 * Increase performance 100x - 1000x by using numpy arrays instead of netcdf variables
 * Improve print statements
 * Add base class for common functions
 * Rewrite CMake build to remove need for templating
 * Fix divide by 0 warnings
 * Error if output directory does not exist

