### PR TITLE
Removed unused imported package (codyssey)

### DIFF
--- a/src/odc/nc2odb.py
+++ b/src/odc/nc2odb.py
@@ -14,7 +14,6 @@ import tempfile
 import argparse
 import datetime as dt
 import netCDF4 as nc
-import codyssey as odc
 
 ###################################################################################
 # SUBROUTINES


### PR DESCRIPTION
This PR cleans up the nc2odb.py script which had a leftover ``import codyssey`` command but was not using that package. This breaks when we go to the release versions of odc and pyodc since the package names in pyodc changed.