### PR TITLE
Fix unicode encoding errors for station id

### DIFF
--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -221,7 +221,11 @@ class NcWriter(object):
             Vector = Values
         elif (Dtype == "string"):
             StringType = "S{0:d}".format(self._nstring)
-            Vector = netCDF4.stringtochar(np.array(Values, StringType))
+            s = np.array(Values, StringType)
+            try:
+                Vector = netCDF4.stringtochar(s)
+            except (UnicodeEncodeError, UnicodeDecodeError) as e:
+                Vector = netCDF4.stringtochar(s, encoding='bytes')
         elif (Dtype == "datetime"):
             StringType = "S{0:d}".format(self._ndatetime)
             Vector = netCDF4.stringtochar(np.array(Values, StringType))


### PR DESCRIPTION
This hopefully fixes `UnicodeEncodeError` and `UnicodeDencodeError` for station ids in some conventional obs produced during the GSI NCDIAGS conversion process.

Honestly, this particular part of the code this patch addresses is a mess and whatever is happening is likely wrong or very inefficient or both, and will need to be eventually refactored to deal with strings in a sane manner.   For now, I'm crossing my fingers that this patch works and isn't papering over any more serious problems.  At least it is now not crashing.