### PR TITLE
Feature/l2 oceancolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Usage: <converter.py> -i INPUT_FILE(S) -o OUTPUT_FILE -d YYYYMMDDHH
   * `hgodas_sst2ioda.py`  
 * `rads_adt2ioda.py` - absolute dynamic topography observations from NOAA/NESDIS. Observations available from `ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/rads/adt`
 * `smap_sss2ioda.py` - SMAP satellite sea surface salinity observations. Observations available from `ftp://podaac-ftp.jpl.nasa.gov/allData/smap/L2/RSS/V3/SCI`
+* `viirs_modis_oc2ioda.py` - L2 satellite ocean color observations from NOAA Coastwatch for VIIRS instruments on board JPSS1/NOAA-20 and SNPP satellites, and from NASA GSFC for MODIS instrument on board Aqua satellite. Observations available from `ftp://ftpcoastwatch.noaa.gov/pub/socd2/mecb/coastwatch/viirs/n20/nrt/L2` (VIIRS-JPSS1/NOAA-20), `ftp://ftpcoastwatch.noaa.gov/pub/socd1/mecb/coastwatch/viirs/nrt/L2` (VIIRS-SNPP), and `https://oceandata.sci.gsfc.nasa.gov/MODIS-Aqua/L2` (MODIS-Aqua).
 
 * `ncep_classes.py` - Convert (prep-)BUFR with embedded BUFR table to IODA format. See [here](src/ncep/README.md) for usage.
 

--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND programs
   rads_adt2ioda.py
   smap_sss2ioda.py
   argoClim2ioda.py
+  viirs_modis_oc2ioda.py
 )
 
 set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )

--- a/src/marine/viirs_modis_oc2ioda.py.in
+++ b/src/marine/viirs_modis_oc2ioda.py.in
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+
+#
+# (C) Copyright 2019 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+
+from __future__ import print_function
+import sys
+import argparse
+import netCDF4 as nc
+from datetime import datetime, timedelta
+import dateutil.parser
+import numpy as np
+from multiprocessing import Pool
+import os
+
+sys.path.append("@SCRIPT_LIB_PATH@")
+import ioda_conv_ncio as iconv
+
+output_var_names = [
+    "ocean_mass_content_of_particulate_organic_matter_expressed_as_carbon",
+    "mass_concentration_of_chlorophyll_in_sea_water"]
+
+
+def read_input(input_args):
+    """
+    Reads/converts a single input file, performing optional thinning also.
+
+    Arguments:
+
+        input_args: A tuple of input filename and global_config
+            input_file: The name of file to read
+            global_config: structure for global arguments related to read
+
+    Returns:
+
+        A tuple of (obs_data, loc_data, attr_data) needed by the IODA writer.
+    """
+    input_file = input_args[0]
+    global_config = input_args[1]
+
+    print("Reading ", input_file)
+    ncd = nc.Dataset(input_file, 'r')
+
+    # get some of the global attributes that we are interested in
+    attr_data = {}
+    for v in ('platform', 'instrument', 'processing_level'):
+        attr_data[v] = ncd.getncattr(v)
+
+    # get the QC flags, and calculate a mask from the non-missing values
+    # (since L2 files are quite empty, fields need a mask applied immediately
+    # to avoid using way too much memory)
+    gpd = ncd.groups['geophysical_data']
+    data_in = {}
+    data_in['l2_flags'] = gpd.variables['l2_flags'][:].ravel()
+    mask = data_in['l2_flags'] < 1073741824
+    data_in['l2_flags'] = data_in['l2_flags'][mask]
+
+    # Determine the lat/lon grid.
+    # If L3, we need to convert 1D lat/lon to 2D lat/lon.
+    # If len(time) > 1, also need to repeat the lat/lon vals
+    ngd = ncd.groups['navigation_data']
+    number_of_lines = len(ngd.variables['longitude'][:, 1])
+    pixels_per_line = len(ngd.variables['longitude'][1, :])
+    lons = ngd.variables['longitude'][:].ravel()[mask]
+    lats = ngd.variables['latitude'][:].ravel()[mask]
+
+    # get the base time (should only have 1 or 2 time slots)
+    sla = ncd.groups['scan_line_attributes']
+    basetime = datetime(sla.variables['year'][0], 1, 1) + \
+        timedelta(days=int(sla.variables['day'][0]-1),
+                  milliseconds=int(sla.variables['msec'][0]))
+    time = (np.repeat(sla.variables['msec'][:].ravel(),
+            pixels_per_line).ravel() - sla.variables['msec'][0])/1000.0
+    data_in['time'] = time[mask]
+
+    # load in all the other data and apply the missing value mask
+    input_vars = ('poc', 'chlor_a')
+    for v in input_vars:
+        if v not in data_in:
+            data_in[v] = gpd.variables[v][:].ravel()[mask]
+    ncd.close()
+
+    # Create a mask for optional random thinning
+    np.random.seed(
+        int((global_config['date']-datetime(1970, 1, 1)).total_seconds()))
+    mask = np.random.uniform(size=len(lons)) > global_config['thin']
+
+    # apply the masks for thinning and missing values
+    lons = lons[mask]
+    lats = lats[mask]
+    data_in['time'] = data_in['time'][mask]
+    data_in['l2_flags'] = data_in['l2_flags'][mask]
+    for v in input_vars:
+        data_in[v] = data_in[v][mask]
+
+    # create a string version of the date for each observation
+    dates = []
+    for i in range(len(lons)):
+        obs_date = basetime + timedelta(seconds=float(data_in['time'][i]))
+        dates.append(obs_date.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    # allocate space for output depending on which variables are to be saved
+    num_vars = 0
+    obs_dim = (len(lons))
+    obs_data = {}
+    if global_config['output_poc']:
+        obs_data[(output_var_names[0], global_config['oval_name'])] = \
+            np.zeros(obs_dim),
+        obs_data[(output_var_names[0], global_config['oerr_name'])] = \
+            np.zeros(obs_dim),
+        obs_data[(output_var_names[0], global_config['opqc_name'])] = \
+            np.zeros(obs_dim),
+        num_vars += 1
+    if global_config['output_chl']:
+        obs_data[(output_var_names[1], global_config['oval_name'])] = \
+            np.zeros(obs_dim),
+        obs_data[(output_var_names[1], global_config['oerr_name'])] = \
+            np.zeros(obs_dim),
+        obs_data[(output_var_names[1], global_config['opqc_name'])] = \
+            np.zeros(obs_dim),
+        num_vars += 1
+
+    # create the final output structures
+    loc_data = {
+        'latitude': lats,
+        'longitude': lons,
+        'datetime': dates,
+    }
+    if global_config['output_poc']:
+        obs_data[(output_var_names[0], global_config['oval_name'])] = \
+            data_in['poc']
+        obs_data[(output_var_names[0], global_config['oerr_name'])] = \
+            data_in['poc']*0.0
+        obs_data[(output_var_names[0], global_config['opqc_name'])] = \
+            data_in['l2_flags']
+    if global_config['output_chl']:
+        obs_data[(output_var_names[1], global_config['oval_name'])] = \
+            data_in['chlor_a']
+        obs_data[(output_var_names[1], global_config['oerr_name'])] = \
+            data_in['chlor_a']*0.0
+        obs_data[(output_var_names[1], global_config['opqc_name'])] = \
+            data_in['l2_flags']
+
+    return (obs_data, loc_data, attr_data)
+
+
+def main():
+
+    # Get command line arguments
+    parser = argparse.ArgumentParser(
+        description=(
+            'Reads the particulate organic carbon and chlorophyll data from'
+            ' VIIRS/MODIS Specification formatted L2 file(s) and converts'
+            ' into IODA formatted output files. Multiple files are'
+            ' concatenated and optional thinning can be performed.')
+    )
+
+    required = parser.add_argument_group(title='required arguments')
+    required.add_argument(
+        '-i', '--input',
+        help="path of VIIRS/MODIS L2 Ocean Color observation input file(s)",
+        type=str, nargs='+', required=True)
+    required.add_argument(
+        '-o', '--output',
+        help="path of IODA output file",
+        type=str, required=True)
+    required.add_argument(
+        '-d', '--date',
+        metavar="YYYYMMDDHH",
+        help="base date for the center of the window",
+        type=str, required=True)
+
+    optional = parser.add_argument_group(title='optional arguments')
+    optional.add_argument(
+        '-t', '--thin',
+        help="percentage of random thinning, from 0.0 to 1.0. Zero indicates"
+             " no thinning is performed. (default: %(default)s)",
+        type=float, default=0.0)
+    optional.add_argument(
+        '--threads',
+        help='multiple threads can be used to load input files in parallel.'
+             ' (default: %(default)s)',
+        type=int, default=1)
+    optional.add_argument(
+        '--poc',
+        help='if set, only poc is output.'
+             ' Otherwise, poc and chlor_a are both output.',
+        action='store_true')
+    optional.add_argument(
+        '--chl',
+        help='if set, only chlor_a (OCI algorithm) is output.'
+             ' Otherwise, poc and chlor_a are both output.',
+        action='store_true')
+
+    args = parser.parse_args()
+    args.date = datetime.strptime(args.date, '%Y%m%d%H')
+    if not args.chl and not args.poc:
+        args.chl = True
+        args.poc = True
+
+    # setup the IODA writer
+    writer = iconv.NcWriter(args.output, [], [])
+
+    # Setup the configuration that is passed to each worker process
+    # Note: Pool.map creates separate processes, and can only take iterable
+    # objects. Rather than using global variables, embed them into
+    # the iterable object together with argument array passed in (args.input)
+    global_config = {}
+    global_config['date'] = args.date
+    global_config['thin'] = args.thin
+    global_config['oval_name'] = writer.OvalName()
+    global_config['oerr_name'] = writer.OerrName()
+    global_config['opqc_name'] = writer.OqcName()
+    global_config['output_poc'] = args.poc
+    global_config['output_chl'] = args.chl
+    pool_inputs = [(i, global_config) for i in args.input]
+
+    # read / process files in parallel
+    pool = Pool(args.threads)
+    obs = pool.map(read_input, pool_inputs)
+
+    # concatenate the data from the files
+    obs_data, loc_data, attr_data = obs[0]
+    loc_data['datetime'] = writer.FillNcVector(
+        loc_data['datetime'], "datetime")
+    for i in range(1, len(obs)):
+        for k in obs_data:
+            axis = len(obs[i][0][k].shape)-1
+            obs_data[k] = np.concatenate(
+                (obs_data[k], obs[i][0][k]), axis=axis)
+        for k in loc_data:
+            d = obs[i][1][k]
+            if k == 'datetime':
+                d = writer.FillNcVector(d, 'datetime')
+            loc_data[k] = np.concatenate((loc_data[k], d), axis=0)
+
+    # prepare global attributes we want to output in the file,
+    # in addition to the ones already loaded in from the input file
+    attr_data['date_time_string'] = args.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    attr_data['thinning'] = args.thin
+    attr_data['converter'] = os.path.basename(__file__)
+
+    # determine which variables we are going to output
+    selected_names = []
+    if args.poc:
+        selected_names.append(output_var_names[0])
+    if args.chl:
+        selected_names.append(output_var_names[1])
+    var_data = {writer._var_list_name:
+                writer.FillNcVector(selected_names, "string")}
+
+    # pass parameters to the IODA writer
+    # (needed because we are bypassing ExtractObsData within BuildNetcdf)
+    writer._nvars = len(selected_names)
+    writer._nlocs = obs_data[(selected_names[0], 'ObsValue')].shape[0]
+
+    # use the writer class to create the final output file
+    writer.BuildNetcdf(obs_data, loc_data, var_data, attr_data)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/marine/viirs_modis_oc2ioda.py.in
+++ b/src/marine/viirs_modis_oc2ioda.py.in
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2020 UCAR
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/marine/viirs_modis_oc2ioda.py.in
+++ b/src/marine/viirs_modis_oc2ioda.py.in
@@ -45,30 +45,28 @@ def read_input(input_args):
     print("Reading ", input_file)
     ncd = nc.Dataset(input_file, 'r')
 
-    # get some of the global attributes that we are interested in
+    # get global attributes
     attr_data = {}
     for v in ('platform', 'instrument', 'processing_level'):
         attr_data[v] = ncd.getncattr(v)
 
-    # get the QC flags, and calculate a mask from the non-missing values
-    # (since L2 files are quite empty, fields need a mask applied immediately
-    # to avoid using way too much memory)
+    # get QC flags, and calculate a mask from the non-missing values
+    # since L2 OC files are quite empty, need a mask applied immediately
+    # to avoid using too much memory)
     gpd = ncd.groups['geophysical_data']
     data_in = {}
     data_in['l2_flags'] = gpd.variables['l2_flags'][:].ravel()
     mask = data_in['l2_flags'] < 1073741824
     data_in['l2_flags'] = data_in['l2_flags'][mask]
 
-    # Determine the lat/lon grid.
-    # If L3, we need to convert 1D lat/lon to 2D lat/lon.
-    # If len(time) > 1, also need to repeat the lat/lon vals
+    # Determine the lat/lon grid
     ngd = ncd.groups['navigation_data']
     number_of_lines = len(ngd.variables['longitude'][:, 1])
     pixels_per_line = len(ngd.variables['longitude'][1, :])
     lons = ngd.variables['longitude'][:].ravel()[mask]
     lats = ngd.variables['latitude'][:].ravel()[mask]
 
-    # get the base time (should only have 1 or 2 time slots)
+    # get basetime and time as a difference in seconds
     sla = ncd.groups['scan_line_attributes']
     basetime = datetime(sla.variables['year'][0], 1, 1) + \
         timedelta(days=int(sla.variables['day'][0]-1),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,9 @@ list( APPEND test_input
   testinput/argoclim_test.nc
   testinput/cryosat2_L2_test.nc
   testinput/CS_OFFL_SIR_GDR_2__20160229T132459_20160229T150412_C001.DBL
+  testinput/viirs_jpss1_oc_l2.nc
+  testinput/viirs_snpp_oc_l2.nc
+  testinput/modis_aqua_oc_l2.nc
   testinput/sondes_obs_2018041500_m.nc4
   testinput/gnssro_obs_2018041500_s.nc4
   testinput/wrfdadiags_goes-16-abi_2018041500.nc
@@ -46,6 +49,9 @@ list( APPEND test_output
   testoutput/argoclim.nc
   testoutput/cryosat2_L2.nc
   testoutput/cryosat2_L2_DBL.nc
+  testoutput/viirs_jpss1_oc_l2.nc
+  testoutput/viirs_snpp_oc_l2.nc
+  testoutput/modis_aqua_oc_l2.nc
   testoutput/sondes_obs_2018041500_m.odb
   testoutput/gnssro_obs_2018041500_s.odb
   testoutput/abi_g16_obs_2018041500.nc4
@@ -202,6 +208,28 @@ ecbuild_add_test( TARGET test_iodaconv_cryosat2_DBL
                        -o testrun/cryosat2_L2_DBL.nc
                        -d 2016022912"
                       cryosat2_L2_DBL.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_viirs_jpss1_oc_l2
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS netcdf
+                       "${CMAKE_BINARY_DIR}/bin/viirs_modis_oc2ioda.py
+                       -i testinput/viirs_jpss1_oc_l2.nc
+                       -o testrun/viirs_jpss1_oc_l2.nc
+                       -d 2018041512
+                       -t 0.5"
+                      viirs_jpss1_oc_l2.nc)
+
+ecbuild_add_test( TARGET test_iodaconv_modis_aqua_oc_l2
+                  TYPE SCRIPT
+                  COMMAND iodaconv_comp.sh
+                  ARGS netcdf
+                       "${CMAKE_BINARY_DIR}/bin/modis_aqua_oc2ioda.py
+                       -i testinput/modis_aqua_oc_l2.nc
+                       -o testrun/modis_aqua_oc_l2.nc
+                       -d 2018041512
+                       -t 0.5"
+                      modis_aqua_oc_l2.nc)
 
 #===============================================================================
 # GSI ncdiag converters

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,6 @@ list( APPEND test_input
   testinput/cryosat2_L2_test.nc
   testinput/CS_OFFL_SIR_GDR_2__20160229T132459_20160229T150412_C001.DBL
   testinput/viirs_jpss1_oc_l2.nc
-  testinput/viirs_snpp_oc_l2.nc
   testinput/modis_aqua_oc_l2.nc
   testinput/sondes_obs_2018041500_m.nc4
   testinput/gnssro_obs_2018041500_s.nc4
@@ -50,7 +49,6 @@ list( APPEND test_output
   testoutput/cryosat2_L2.nc
   testoutput/cryosat2_L2_DBL.nc
   testoutput/viirs_jpss1_oc_l2.nc
-  testoutput/viirs_snpp_oc_l2.nc
   testoutput/modis_aqua_oc_l2.nc
   testoutput/sondes_obs_2018041500_m.odb
   testoutput/gnssro_obs_2018041500_s.odb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -222,7 +222,7 @@ ecbuild_add_test( TARGET test_iodaconv_modis_aqua_oc_l2
                   TYPE SCRIPT
                   COMMAND iodaconv_comp.sh
                   ARGS netcdf
-                       "${CMAKE_BINARY_DIR}/bin/modis_aqua_oc2ioda.py
+                       "${CMAKE_BINARY_DIR}/bin/viirs_modis_oc2ioda.py
                        -i testinput/modis_aqua_oc_l2.nc
                        -o testrun/modis_aqua_oc_l2.nc
                        -d 2018041512

--- a/test/testinput/modis_aqua_oc_l2.nc
+++ b/test/testinput/modis_aqua_oc_l2.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efabd65f91ea0046f9788e08dee44aa676db285091883ccad9af15ca072117cf
+size 1139656

--- a/test/testinput/viirs_jpss1_oc_l2.nc
+++ b/test/testinput/viirs_jpss1_oc_l2.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e046a87034764ee34c7dd9e90854cc19ddaeae509a4af733ee552e76ad811cc
+size 973009

--- a/test/testoutput/modis_aqua_oc_l2.nc
+++ b/test/testoutput/modis_aqua_oc_l2.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c362f22377f2c5b800ca66a406da69f498db4570a1d66fc3dfbcb8d0e7d0d3e3
+size 218834

--- a/test/testoutput/viirs_jpss1_oc_l2.nc
+++ b/test/testoutput/viirs_jpss1_oc_l2.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:521bc4c5d8d555c1ff19fe1cab5dc2d1bd7fb46250e67a5eded6c1505261c27e
+size 377932


### PR DESCRIPTION
This PR adds converters in python for ocean color L2 data (i.e. particulate organic carbon and chlorophyll) from VIIRS and MODIS. The conversion is from the native format of the provider to ioda NetCDF. The converters are needed for the Ocean DA activities.

Users have the option to convert and output only --poc or --chl data. If not specified, both pop and chl will be in output.

Corresponding ctests are added. Test files (viirs_jpss1_oc_l2.nc and modis_aqua_oc_l2.nc) are added to the /testinput and /testoutput folders.

This PR addresses issue #267.

Closes #267
