### PR TITLE
Fix ncdiags converter utf-8 conversion errors??

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build*
 *DS_Store*
 ._*
 *.swp
+_build*
+_install*

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -761,7 +761,7 @@ class Conv(BaseGSI):
                     loc_mdata_name = all_LocKeyList[lvar][0]
                     if lvar == 'Station_ID':
                         tmp = self.var(lvar)[idx]
-                        StationIDs = [b''.join(tmp[a]) for a in range(len(tmp))]
+                        StationIDs = [str(b''.join(tmp[a])) for a in range(len(tmp))]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(StationIDs, "string")
                     elif lvar == 'Time':  # need to process into time stamp strings #"%Y-%m-%dT%H:%M:%SZ"
                         tmp = self.var(lvar)[idx]

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -761,7 +761,7 @@ class Conv(BaseGSI):
                     loc_mdata_name = all_LocKeyList[lvar][0]
                     if lvar == 'Station_ID':
                         tmp = self.var(lvar)[idx]
-                        StationIDs = [str(b''.join(tmp[a])) for a in range(len(tmp))]
+                        StationIDs = [bytes((b''.join(tmp[a])).decode('iso-8859-1').encode('utf8')) for a in range(len(tmp))]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(StationIDs, "string")
                     elif lvar == 'Time':  # need to process into time stamp strings #"%Y-%m-%dT%H:%M:%SZ"
                         tmp = self.var(lvar)[idx]


### PR DESCRIPTION
Fix ncdiags converter utf-8 conversion errors.   Convert to a string before passing to `netCDF4.stringtochar()` which doesn't understand non-utf8 compliant codes.

This appears to be a new problem starting with data from `20200427_1800Z` cycle.  This is a quick and dirty fix.  I'm curious to actually look over this code a bit more in detail.  Hopefully, there are not more problems like this lurking.  I'm not sure why what could be as simple as a list of strings is formatted as a 2d numpy array of null-terminated byte sequences of length 1.  We'll need to review this bit again when I have more time.

Symptom is:
```molah@s4-submit ~/.jedi-rapids/scratch/obs-gsi-ingest/2020042800/master/2020042800_obs.tar $ ~/.jedi-rapids/prefix/intel17/bin/test_gsidiag.py  -o /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs -i /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/diag_conv_uv_ges.2020042718_ensmean.nc4 -t conv
Platform:sfc Var:uv #Obs:63749
ProcessedL 63749 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/sfc_uv_obs_2020042718.nc4
Platform:aircraft Var:uv #Obs:43984
ProcessedL 43984 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/aircraft_uv_obs_2020042718.nc4
Platform:sondes Var:uv #Obs:1381
ProcessedL 1381 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/sondes_uv_obs_2020042718.nc4
Platform:vadwind Var:uv #Obs:13838
ProcessedL 13838 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/vadwind_obs_2020042718.nc4
Platform:windprof Var:uv #Obs:12
ProcessedL 12 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/windprof_obs_2020042718.nc4
Platform:sfcship Var:uv #Obs:10907
ProcessedL 10907 Conventional obs processed to: /scratch/users/molah/jedirapids/scratch/obs-gsi-ingest/2020042718/master/2020042718_obs.tar/obs/sfcship_uv_obs_2020042718.nc4
Platform:satwind Var:uv #Obs:3233110
Traceback (most recent call last):
  File "/home/molah/.jedi-rapids/prefix/intel17/bin/test_gsidiag.py", line 63, in <module>
    diag.toIODAobs(outdir)
  File "/home/molah/.jedi-rapids/prefix/intel17/lib/pyiodaconv/gsi_ncdiag.py", line 765, in toIODAobs
    loc_mdata[loc_mdata_name] = writer.FillNcVector(StationIDs, "string")
  File "/home/molah/.jedi-rapids/prefix/intel17/lib/pyiodaconv/ioda_conv_ncio.py", line 224, in FillNcVector
    Vector = netCDF4.stringtochar(np.array(Values, StringType))
  File "netCDF4/_netCDF4.pyx", line 6096, in netCDF4._netCDF4.stringtochar
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2 in position 0: invalid start byte

```