### PR TITLE
Fixed coding norm error that surfaced when pycodestyle was upgraded

### DIFF
--- a/src/marine/godae_profile2ioda.py.in
+++ b/src/marine/godae_profile2ioda.py.in
@@ -195,14 +195,14 @@ class IODA(object):
                 lon = obs.data['ob_lon'][n]
                 dtg = datetime.strptime(obs.data['ob_dtg'][n], '%Y%m%d%H%M')
 
-                for l, lvl in enumerate(obs.data['ob_lvl'][n]):
+                for ilev, lvl in enumerate(obs.data['ob_lvl'][n]):
 
                     locKey = lat, lon, lvl, dtg.strftime("%Y-%m-%dT%H:%M:%SZ")
 
                     for key in self.varDict.keys():
 
-                        val = obs.data[key][n][l]
-                        err = obs.data[key+'_err'][n][l]
+                        val = obs.data[key][n][ilev]
+                        err = obs.data[key+'_err'][n][ilev]
                         qc = (100 * obs.data[key+'_qc'][n]).astype('i4')
 
                         valKey = self.keyDict[key]['valKey']


### PR DESCRIPTION
This PR fixes a new code style error (E741) where the variable 'l' (lower case ell) was being flagged as an ambiguous variable name. The idea behind the new check is to flush out single letter variable names that look like numerical digits (in this case lower case ell looks like the digit one).

Closes #282 