### PR TITLE
Remove MetaVars which have empty data in ncdiags from lists in combine_conv.py

### DIFF
--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -89,7 +89,7 @@ def concat_ioda(FileList, OutFile, GeoDir):
             ncf.close()
     # extract metadata and generate a numpy array
     MetaVarData = []
-    MetaVarUnique = []
+    bad_idxs = []
     for v in MetaVars:
         tmpvardata = []
         if MetaInAll[v]:
@@ -103,8 +103,16 @@ def concat_ioda(FileList, OutFile, GeoDir):
             tmpvardata = np.vstack(tmpvardata)
             tmpvardata = np.array([b''.join(td) for td in tmpvardata])
         except IndexError:
-            tmpvardata = np.hstack(tmpvardata)
-        MetaVarData.append(tmpvardata)
+            if len(tmpvardata):
+                tmpvardata = np.hstack(tmpvardata)
+        if len(tmpvardata):
+            MetaVarData.append(tmpvardata)
+        else:
+            bad_idxs.append(MetaVars.index(v))
+    for i in sorted(bad_idxs,reverse=True):
+        del MetaVars[i]
+        del MetaVarNames[i]
+        del MetaVType[i]
     MetaVarData = np.vstack(MetaVarData)
     MetaVarUnique, idx, inv, cnt = np.unique(MetaVarData, return_index=True, return_inverse=True, return_counts=True, axis=1)
     # grab variables to write out

--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -109,7 +109,7 @@ def concat_ioda(FileList, OutFile, GeoDir):
             MetaVarData.append(tmpvardata)
         else:
             bad_idxs.append(MetaVars.index(v))
-    for i in sorted(bad_idxs,reverse=True):
+    for i in sorted(bad_idxs, reverse=True):
         del MetaVars[i]
         del MetaVarNames[i]
         del MetaVType[i]

--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -102,7 +102,7 @@ def concat_ioda(FileList, OutFile, GeoDir):
             ashape = tmpdata.shape[1]
             tmpvardata = np.vstack(tmpvardata)
             tmpvardata = np.array([b''.join(td) for td in tmpvardata])
-        except (IndexError,ValueError):
+        except (IndexError, ValueError):
             if len(tmpvardata):
                 tmpvardata = np.hstack(tmpvardata)
         if len(tmpvardata):

--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -102,7 +102,7 @@ def concat_ioda(FileList, OutFile, GeoDir):
             ashape = tmpdata.shape[1]
             tmpvardata = np.vstack(tmpvardata)
             tmpvardata = np.array([b''.join(td) for td in tmpvardata])
-        except IndexError:
+        except (IndexError,ValueError):
             if len(tmpvardata):
                 tmpvardata = np.hstack(tmpvardata)
         if len(tmpvardata):


### PR DESCRIPTION
This fixes a bug where if the `MetaVarData` is empty for some meta variables, the concatenation process will break.  Instead of keeping around all the broken metavariables, I am deleting those that are empty/erronous.  This seems to fix the problem with the `2020061506_obs.tar` and later gsi ncdiags conversion.  I am having some difficulty fully testing due to unrelated updates with fv3-bundle which are preventing a jedi-rapids build from completing.  I am about 90% sure this should be working, but let's hold off on merge until I get the jedi-rapids build working again.