### PR TITLE
Performance improvement for NcWriter DateTime conversions

### DIFF
--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -187,14 +187,14 @@ class NcWriter(object):
         ref_offset = math.floor(self._ref_date_time.hour*3600. + self._ref_date_time.minute*60. + self._ref_date_time.second)/3600.  # decimal hours
         date_offset_cache = {}  # Cache a map from bytes[0:10] to the corresponding date's offset from reference date
         for i in range(len(datestr_vec)):
-            date_str = datestr_vec[i][0:10].tobytes()
-            date_offset = date_offset_cache.get(date_str)
+            date_bytes = datestr_vec[i].tobytes()
+            date_offset = date_offset_cache.get(date_bytes[0:10])
             if date_offset is None:
                 # There are at most 2 distinct dates per cycle for any window length < 24hrs
-                date_offset = (dt.date.fromisoformat(date_str.decode('ascii')) - self._ref_date_time.date()).total_seconds()/3600.
-                date_offset_cache[date_str] = date_offset
-            t = dt.time.fromisoformat(datestr_vec[i][11:19].tobytes().decode('ascii'))
-            t_offset = math.floor(t.hour*3600. + t.minute*60. + t.second)/3600.
+                delta = dt.date(int(date_bytes[0:4]), int(date_bytes[5:7]), int(date_bytes[8:10])) - self._ref_date_time.date()
+                date_offset = delta.total_seconds()/3600.
+                date_offset_cache[date_bytes[0:10]] = date_offset
+            t_offset = (int(date_bytes[11:13])*3600. + int(date_bytes[14:16])*60. + int(date_bytes[17:19]))/3600.
             offset[i] = date_offset + (t_offset - ref_offset)
         return offset
 


### PR DESCRIPTION
While testing performance of @CoryMartin-NOAA 's new `tropomi_no2_nc2ioda.py` in PR #300, I noticed that the majority of the time was spent in `NcWriter::ConvertToTimeOffset` which parses datetime strings in ioda format and converts to the decimal hour float32 offset used in the `Time@MetaData`.  Since this was bottlenecking the whole converter there was not much sense in trying to optimize the tropomi converter itself any further until this was addressed.  

Now I think this PR should remove the bottleneck and allow further performance profiling and improvements.

Percent of total runtime spent in `NcWriter::ConvertToTimeOffset` (with 45MB NetCDF datasource):
* Original: `2.67 s / 3.38 s = 79%` ![tropomi_orig_ConvertToTimeOffset](https://user-images.githubusercontent.com/14096120/89942982-b5f04f80-dbda-11ea-8ebf-0233cbe540cb.png)
* Improved:  `0.284 s / 1.16 s = 24%` ![tropomi_improved_ConvertToTimeOffset](https://user-images.githubusercontent.com/14096120/89943068-d9b39580-dbda-11ea-91db-a7938e443518.png)

Overall runtime without profiler overhead 
* Original: 2.78 s 
* Improved: 0.996 s 
* **Speedup factor: 2.8** 

Strategy:
Knowing that the dates are almost always going to be all the same or at most two different dates, we compute and cache the date time offsets based on the bytes representation of the first 10 chars.  Next, we convert only the time part of the string to datetime.time and compute the offset from 0000Z on the given date.  Along with a pre-computed offset for the time part of the reference date, we can compute the overall offset.  

**Notes:** 
 * The `fromisoformat()` functions are much faster than `strptime` because they are less generic, but they match our format for the date and time parts individually.
 * It's important to round offsets to integer seconds and then convert to decimal hours, to match the implementation of `timedelta.total_seconds()` and exactly reproduce the reference behavior.
 * I also tried a few methods of computing the offset directly from converted digits of the time and all methods were less efficient than this version. [Edit: this method was actually faster and also python-3.6 compatible, so is implemented in the final version]
 * I have tested a few other converters and saw only modest speedup.  It seems bottlenecks in other scripts are elsewhere, but I will test with the whole ncdiags pipeline to see if there is any noticeable effect.
