### PR TITLE
Bugfix/pyiodaconv installdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,9 @@ endif()
 set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 
 # Location of installed python iodaconv libraries
+include(GNUInstallDirs)
 set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/pyiodaconv )
-set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib/pyiodaconv )
+set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ################################################################################
 # Sources

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -37,15 +37,14 @@ add_custom_target( install_bin_python_scripts ALL
     COMMAND chmod +x ${install_bin_python_scripts_deps}
     DEPENDS ${install_bin_python_scripts_deps} )
 
+
 install( PROGRAMS
   ${install_bin_python_scripts_deps}
   DESTINATION bin
 )
 
-install( FILES
-  ${lib_python_scripts_deps}
-  DESTINATION lib/pyiodaconv
-)
+include(GNUInstallDirs)
+install( FILES ${lib_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms
                   TYPE SCRIPT

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -43,7 +43,6 @@ install( PROGRAMS
   DESTINATION bin
 )
 
-include(GNUInstallDirs)
 install( FILES ${lib_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms


### PR DESCRIPTION
This ensures that the `PYIODACONV_INSTALL_LIBDIR` matches with the `CMAKE_INSTALL_LIBDIR` rather than hardcoded to `lib/`.   This only effects the installed location, not the build location, so tests should be unaffected.