### PR TITLE
Bugfix/pyiodaconv installdir try2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,9 @@ endif()
 set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 
 # Location of installed python iodaconv libraries
+include(GNUInstallDirs)
 set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/pyiodaconv )
-set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib/pyiodaconv )
+set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ################################################################################
 # Sources

--- a/cmake/iodaconv_extra_macros.cmake
+++ b/cmake/iodaconv_extra_macros.cmake
@@ -16,12 +16,7 @@ macro( SET_TARGETS_DEPS filelist source destination deplist)
     set ( SOURCE_FILE ${source}/${FILENAME} )
     set ( DEST_FILE ${destination}/${FILENAME} )
     list( APPEND ${deplist} ${DEST_FILE} )
-    add_custom_command(
-      OUTPUT ${DEST_FILE}
-      DEPENDS ${SOURCE_FILE}
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${destination}
-      COMMAND ${CMAKE_COMMAND} -E copy ${SOURCE_FILE} ${DEST_FILE}
-    )
+    configure_file( ${SOURCE_FILE} ${DEST_FILE} COPYONLY )
   endforeach(FILENAME)
 endmacro( SET_TARGETS_DEPS )
 

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -48,12 +48,12 @@ COPY_FILES( "${configs}"
 
 install( PROGRAMS
   ${install_bin_odb2_scripts_deps}
-  DESTINATION bin
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install( FILES
   ${odb2_scripts_deps}
-  DESTINATION lib/pyiodaconv
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv
 )
 
 # ODB "definition" files which are configurations for the odbapi2nc.py script.

--- a/src/ODB2/CMakeLists.txt
+++ b/src/ODB2/CMakeLists.txt
@@ -20,51 +20,36 @@ SET_TARGETS_DEPS( "${libs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${PYIODACONV_BUILD_LIBDIR}
                    odb2_scripts_deps)
-add_custom_target( odb2_scripts ALL DEPENDS ${odb2_scripts_deps} )
 
 set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_odb2_scripts_deps)
-add_custom_target( bin_odb2_scripts ALL
-    COMMAND chmod +x ${bin_odb2_scripts_deps}
-    DEPENDS ${bin_odb2_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_odb2_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_odb2_scripts_deps)
-add_custom_target( install_bin_odb2_scripts ALL
-    COMMAND chmod +x ${install_bin_odb2_scripts_deps}
-    DEPENDS ${install_bin_odb2_scripts_deps} )
 
 # ODB "definition" files which are configurations for the odbapi2nc.py script.
 COPY_FILES( "${configs}"
             ${CMAKE_CURRENT_SOURCE_DIR}/Definitions
             ${CMAKE_BINARY_DIR}/etc/pyiodaconv )
 
-install( PROGRAMS
-  ${install_bin_odb2_scripts_deps}
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+install( PROGRAMS ${install_bin_odb2_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install( FILES
-  ${odb2_scripts_deps}
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv
-)
+install( FILES ${odb2_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 # ODB "definition" files which are configurations for the odbapi2nc.py script.
 foreach (FILENAME ${configs})
   list( APPEND build_area_configs ${CMAKE_BINARY_DIR}/etc/pyiodaconv/${FILENAME} )
 endforeach(FILENAME)
 
-install( FILES
-   ${build_area_configs}
-   DESTINATION etc/pyiodaconv
-)
+install( FILES ${build_area_configs} DESTINATION ${CMAKE_INSTALL_DATADIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_odb2_coding_norms
                   TYPE SCRIPT

--- a/src/chem/CMakeLists.txt
+++ b/src/chem/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_target( install_bin_chem_scripts ALL
 
 install( PROGRAMS
   ${install_bin_chem_scripts_deps}
-  DESTINATION bin
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 ecbuild_add_test( TARGET iodaconv_chem_coding_norms

--- a/src/chem/CMakeLists.txt
+++ b/src/chem/CMakeLists.txt
@@ -8,24 +8,16 @@ CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_chem_scripts_deps)
-add_custom_target( bin_chem_scripts ALL
-    COMMAND chmod +x ${bin_chem_scripts_deps}
-    DEPENDS ${bin_chem_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_chem_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_chem_scripts_deps)
-add_custom_target( install_bin_chem_scripts ALL
-    COMMAND chmod +x ${install_bin_chem_scripts_deps}
-    DEPENDS ${install_bin_chem_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_chem_scripts_deps}
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+install( PROGRAMS ${install_bin_chem_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 ecbuild_add_test( TARGET iodaconv_chem_coding_norms
                   TYPE

--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(_file IN LISTS libs)
 endforeach()
 
 install(PROGRAMS ${programs} DESTINATION bin)
-install(FILES ${libs} DESTINATION lib/pyiodaconv)
+install(FILES ${libs} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv)
 
 ecbuild_add_test( TARGET iodaconv_gsi-ncdiag_coding_norms
                   TYPE SCRIPT

--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -6,17 +6,29 @@ list( APPEND programs
   combine_conv.py
   subset_files.py)
 
-foreach(_file IN LISTS programs)
-    add_custom_target(${_file} ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${CMAKE_BINARY_DIR}/bin/${_file}
-                               DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
-endforeach()
-foreach(_file IN LISTS libs)
-    add_custom_target(${_file} ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_file} ${CMAKE_BINARY_DIR}/lib/pyiodaconv/${_file}
-                               DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
-endforeach()
 
-install(PROGRAMS ${programs} DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES ${libs} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv)
+SET_TARGETS_DEPS( "${libs}"
+                   ${CMAKE_CURRENT_SOURCE_DIR}
+                   ${PYIODACONV_BUILD_LIBDIR}
+                   gsi_ncdiag_lib_deps )
+
+set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
+CONF_TARGETS_DEPS( "${programs}"
+                   ${CMAKE_CURRENT_SOURCE_DIR}
+                   ${CMAKE_BINARY_DIR}/bin
+                   gsi_ncdiag_bin_deps)
+execute_process(COMMAND chmod +x ${gsi_ncdiag_bin_deps})
+
+# Configure files for install prefix bin
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
+CONF_TARGETS_DEPS( "${programs}"
+                   ${CMAKE_CURRENT_SOURCE_DIR}
+                   ${CMAKE_BINARY_DIR}/install-bin
+                   gsi_ncdiag_bin_install_deps)
+
+install( PROGRAMS ${gsi_ncdiag_bin_install_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
+
+install( FILES ${gsi_ncdiag_lib_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_gsi-ncdiag_coding_norms
                   TYPE SCRIPT

--- a/src/gsi-ncdiag/CMakeLists.txt
+++ b/src/gsi-ncdiag/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(_file IN LISTS libs)
                                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_file})
 endforeach()
 
-install(PROGRAMS ${programs} DESTINATION bin)
+install(PROGRAMS ${programs} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${libs} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv)
 
 ecbuild_add_test( TARGET iodaconv_gsi-ncdiag_coding_norms

--- a/src/gsi-ncdiag/combine_conv.py
+++ b/src/gsi-ncdiag/combine_conv.py
@@ -12,8 +12,13 @@ from collections import defaultdict, OrderedDict
 import datetime as dt
 from pathlib import Path
 
-prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
-sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+# Locate src/lib-python/ioda_conv_ncio
+# TODO Replace with setup.py
+IODA_CONV_PATH = "@SCRIPT_LIB_PATH@"
+if Path(IODA_CONV_PATH).is_dir():
+    sys.path.append(IODA_CONV_PATH)
+else:
+    sys.path.append(str((Path(__file__).parent/'..'/'lib-python').resolve()))
 
 import ioda_conv_ncio as iconv
 from orddicts import DefaultOrderedDict

--- a/src/gsi-ncdiag/proc_gsi_ncdiag.py
+++ b/src/gsi-ncdiag/proc_gsi_ncdiag.py
@@ -7,8 +7,13 @@ import time
 from multiprocessing import Pool
 from pathlib import Path
 
-prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
-sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+# Locate src/lib-python/gsi
+# TODO Replace with setup.py
+IODA_CONV_PATH = "@SCRIPT_LIB_PATH@"
+if Path(IODA_CONV_PATH).is_dir():
+    sys.path.append(IODA_CONV_PATH)
+else:
+    sys.path.append(str((Path(__file__).parent/'..'/'lib-python').resolve()))
 
 import gsi_ncdiag as gsid
 

--- a/src/gsi-ncdiag/test_gsidiag.py
+++ b/src/gsi-ncdiag/test_gsidiag.py
@@ -4,8 +4,13 @@ import sys
 import argparse
 from pathlib import Path
 
-prefix_lib_path = Path(__file__).absolute().parent.parent/'lib'
-sys.path.append(str(prefix_lib_path/'pyiodaconv'))
+# Locate src/lib-python/ioda_conv_ncio
+# TODO Replace with setup.py
+IODA_CONV_PATH = "@SCRIPT_LIB_PATH@"
+if Path(IODA_CONV_PATH).is_dir():
+    sys.path.append(IODA_CONV_PATH)
+else:
+    sys.path.append(str(Path(__file__).parent))
 
 import gsi_ncdiag as gsid
 

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -38,10 +38,7 @@ add_custom_target( install_bin_python_scripts ALL
     DEPENDS ${install_bin_python_scripts_deps} )
 
 
-install( PROGRAMS
-  ${install_bin_python_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 install( FILES ${lib_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -15,7 +15,6 @@ SET_TARGETS_DEPS( "${libs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${PYIODACONV_BUILD_LIBDIR}
                    lib_python_scripts_deps)
-add_custom_target( lib_python_scripts ALL DEPENDS ${lib_python_scripts_deps} )
 
 # Configure files for local bin
 set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
@@ -23,19 +22,14 @@ CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_python_scripts_deps)
-add_custom_target( bin_python_scripts ALL
-    COMMAND chmod +x ${bin_python_scripts_deps}
-    DEPENDS ${bin_python_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_python_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_python_scripts_deps)
-add_custom_target( install_bin_python_scripts ALL
-    COMMAND chmod +x ${install_bin_python_scripts_deps}
-    DEPENDS ${install_bin_python_scripts_deps} )
 
 install( PROGRAMS ${install_bin_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -37,15 +37,14 @@ add_custom_target( install_bin_python_scripts ALL
     COMMAND chmod +x ${install_bin_python_scripts_deps}
     DEPENDS ${install_bin_python_scripts_deps} )
 
+
 install( PROGRAMS
   ${install_bin_python_scripts_deps}
   DESTINATION bin
 )
 
-install( FILES
-  ${lib_python_scripts_deps}
-  DESTINATION lib/pyiodaconv
-)
+include(GNUInstallDirs)
+install( FILES ${lib_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms
                   TYPE SCRIPT

--- a/src/lib-python/CMakeLists.txt
+++ b/src/lib-python/CMakeLists.txt
@@ -43,7 +43,6 @@ install( PROGRAMS
   DESTINATION bin
 )
 
-include(GNUInstallDirs)
 install( FILES ${lib_python_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_lib-python_coding_norms

--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -35,10 +35,7 @@ add_custom_target( install_bin_marine_scripts ALL
     COMMAND chmod +x ${install_bin_marine_scripts_deps}
     DEPENDS ${install_bin_marine_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_marine_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_marine_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 ecbuild_add_test( TARGET iodaconv_marine_coding_norms
                   TYPE

--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -21,19 +21,14 @@ CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_marine_scripts_deps)
-add_custom_target( bin_marine_scripts ALL
-    COMMAND chmod +x ${bin_marine_scripts_deps}
-    DEPENDS ${bin_marine_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_marine_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
-                   ${CMAKE_CURRENT_SOURCE_DIR}
-                   ${CMAKE_BINARY_DIR}/install-bin
-                   install_bin_marine_scripts_deps)
-add_custom_target( install_bin_marine_scripts ALL
-    COMMAND chmod +x ${install_bin_marine_scripts_deps}
-    DEPENDS ${install_bin_marine_scripts_deps} )
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_BINARY_DIR}/install-bin
+            install_bin_marine_scripts_deps)
 
 install( PROGRAMS ${install_bin_marine_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 

--- a/src/ncep/CMakeLists.txt
+++ b/src/ncep/CMakeLists.txt
@@ -39,32 +39,25 @@ SET_TARGETS_DEPS( "${libs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${PYIODACONV_BUILD_LIBDIR}
                    ncep_scripts_deps)
-add_custom_target( ncep_scripts ALL DEPENDS ${ncep_scripts_deps} )
 
 SET_TARGETS_DEPS( "${config}"
                    ${CMAKE_CURRENT_SOURCE_DIR}/config
                    ${PYIODACONV_BUILD_LIBDIR}/config
                    config_ncep_scripts_deps)
-add_custom_target( config_ncep_scripts ALL DEPENDS ${config_ncep_scripts_deps} )
 
 set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_ncep_scripts_deps)
-add_custom_target( bin_ncep_scripts ALL
-    COMMAND chmod +x ${bin_ncep_scripts_deps}
-    DEPENDS ${bin_ncep_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_ncep_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_ncep_scripts_deps)
-add_custom_target( install_bin_ncep_scripts ALL
-    COMMAND chmod +x ${install_bin_ncep_scripts_deps}
-    DEPENDS ${install_bin_ncep_scripts_deps} )
 
 install( PROGRAMS ${install_bin_ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 

--- a/src/ncep/CMakeLists.txt
+++ b/src/ncep/CMakeLists.txt
@@ -70,10 +70,7 @@ install( PROGRAMS ${install_bin_ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_B
 
 install( FILES ${ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
-install( FILES
-  ${config_ncep_scripts_deps}
-  DESTINATION lib/pyiodaconv/config
-)
+install( FILES ${config_ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv/config )
 
 ecbuild_add_test( TARGET iodaconv_ncep_coding_norms
                   TYPE SCRIPT

--- a/src/ncep/CMakeLists.txt
+++ b/src/ncep/CMakeLists.txt
@@ -66,15 +66,9 @@ add_custom_target( install_bin_ncep_scripts ALL
     COMMAND chmod +x ${install_bin_ncep_scripts_deps}
     DEPENDS ${install_bin_ncep_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_ncep_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install( FILES
-  ${ncep_scripts_deps}
-  DESTINATION lib/pyiodaconv
-)
+install( FILES ${ncep_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 install( FILES
   ${config_ncep_scripts_deps}

--- a/src/nsmc/CMakeLists.txt
+++ b/src/nsmc/CMakeLists.txt
@@ -21,10 +21,7 @@ add_custom_target( install_bin_nsmc_scripts ALL
     COMMAND chmod +x ${install_bin_nsmc_scripts_deps}
     DEPENDS ${install_bin_nsmc_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_nsmc_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_nsmc_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 ecbuild_add_test( TARGET iodaconv_nsmc_coding_norms
                   TYPE

--- a/src/nsmc/CMakeLists.txt
+++ b/src/nsmc/CMakeLists.txt
@@ -7,19 +7,14 @@ CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_nsmc_scripts_deps)
-add_custom_target( bin_nsmc_scripts ALL
-    COMMAND chmod +x ${bin_nsmc_scripts_deps}
-    DEPENDS ${bin_nsmc_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_nsmc_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_nsmc_scripts_deps)
-add_custom_target( install_bin_nsmc_scripts ALL
-    COMMAND chmod +x ${install_bin_nsmc_scripts_deps}
-    DEPENDS ${install_bin_nsmc_scripts_deps} )
 
 install( PROGRAMS ${install_bin_nsmc_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 

--- a/src/odc/CMakeLists.txt
+++ b/src/odc/CMakeLists.txt
@@ -9,19 +9,14 @@ CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_odc_scripts_deps)
-add_custom_target( bin_odc_scripts ALL
-    COMMAND chmod +x ${bin_odc_scripts_deps}
-    DEPENDS ${bin_odc_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_odc_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_odc_scripts_deps)
-add_custom_target( install_bin_odc_scripts ALL
-    COMMAND chmod +x ${install_bin_odc_scripts_deps}
-    DEPENDS ${install_bin_odc_scripts_deps} )
 
 install( PROGRAMS ${install_bin_odc_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 

--- a/src/odc/CMakeLists.txt
+++ b/src/odc/CMakeLists.txt
@@ -23,10 +23,7 @@ add_custom_target( install_bin_odc_scripts ALL
     COMMAND chmod +x ${install_bin_odc_scripts_deps}
     DEPENDS ${install_bin_odc_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_odc_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_odc_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 ecbuild_add_test( TARGET iodaconv_odc_coding_norms
                   TYPE

--- a/src/wrfda-ncdiag/CMakeLists.txt
+++ b/src/wrfda-ncdiag/CMakeLists.txt
@@ -32,15 +32,9 @@ add_custom_target( install_bin_wrfda_ncdiag_scripts ALL
     COMMAND chmod +x ${install_bin_wrfda_ncdiag_scripts_deps}
     DEPENDS ${install_bin_wrfda_ncdiag_scripts_deps} )
 
-install( PROGRAMS
-  ${install_bin_wrfda_ncdiag_scripts_deps}
-  DESTINATION bin
-)
+install( PROGRAMS ${install_bin_wrfda_ncdiag_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install( FILES
-  ${wrfda_ncdiag_scripts_deps}
-  DESTINATION lib/pyiodaconv
-)
+install( FILES ${wrfda_ncdiag_scripts_deps} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
 
 ecbuild_add_test( TARGET iodaconv_wrfda-ncdiag_coding_norms
                   TYPE SCRIPT

--- a/src/wrfda-ncdiag/CMakeLists.txt
+++ b/src/wrfda-ncdiag/CMakeLists.txt
@@ -11,26 +11,20 @@ SET_TARGETS_DEPS( "${libs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${PYIODACONV_BUILD_LIBDIR}
                    wrfda_ncdiag_scripts_deps)
-add_custom_target( wrfda_ncdiag_scripts ALL DEPENDS ${wrfda_ncdiag_scripts_deps} )
 
 set( SCRIPT_LIB_PATH ${PYIODACONV_BUILD_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/bin
                    bin_wrfda_ncdiag_scripts_deps)
-add_custom_target( bin_wrfda_ncdiag_scripts ALL
-    COMMAND chmod +x ${bin_wrfda_ncdiag_scripts_deps}
-    DEPENDS ${bin_wrfda_ncdiag_scripts_deps} )
+execute_process(COMMAND chmod +x ${bin_wrfda_ncdiag_scripts_deps})
 
 # Configure files for install prefix bin
-set( SCRIPT_LIB_PATH ${PYIODACONV_INSTALL_LIBDIR} )
+file(RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_INSTALL_FULL_BINDIR} ${PYIODACONV_INSTALL_LIBDIR} )
 CONF_TARGETS_DEPS( "${programs}"
                    ${CMAKE_CURRENT_SOURCE_DIR}
                    ${CMAKE_BINARY_DIR}/install-bin
                    install_bin_wrfda_ncdiag_scripts_deps)
-add_custom_target( install_bin_wrfda_ncdiag_scripts ALL
-    COMMAND chmod +x ${install_bin_wrfda_ncdiag_scripts_deps}
-    DEPENDS ${install_bin_wrfda_ncdiag_scripts_deps} )
 
 install( PROGRAMS ${install_bin_wrfda_ncdiag_scripts_deps} DESTINATION ${CMAKE_INSTALL_BINDIR} )
 


### PR DESCRIPTION
@srherbener and @CoryMartin-NOAA, you guys are too fast.  Thanks for the quick merge on #308 but I just found some other locations I overlooked and wasn't able to push the updates before the PR got merged.  

These changes are on the same lines as before.  I also changed the installs to `bin/` to use `CMAKE_INSTALL_BINDIR` for symmetry and correctness, but this always evaluates to `bin/` on all the platforms we use anyways.

To check that it is working it is necessary to call ecbuild with an install prefix and do make install.
```
cd <ioda-converters>
ecbuild -H. -B_build -DCMAKE_INSTALL_PREFIX=_install
cd _build
make -j8 install
```
There should be a `bin` and either a `lib` or a `lib64` (but not both) depending on your platform under `_install` prefix.